### PR TITLE
Feat/localstore

### DIFF
--- a/core/store/errors.go
+++ b/core/store/errors.go
@@ -1,0 +1,5 @@
+package store
+
+import "errors"
+
+var ErrViewDoesNotExist = errors.New("view already exists")

--- a/core/store/errors.go
+++ b/core/store/errors.go
@@ -2,4 +2,5 @@ package store
 
 import "errors"
 
-var ErrViewDoesNotExist = errors.New("view already exists")
+var ErrViewAlreadyExist = errors.New("view already exists")
+var ErrViewDoesNotExist = errors.New("view does not exists")

--- a/core/store/interface.go
+++ b/core/store/interface.go
@@ -11,20 +11,20 @@ import "github.com/shinzonetwork/view-creator/core/models"
 type ViewStore interface {
 	// Create initializes and stores a new view with the given name and timestamp.
 	// Returns the newly created View.
-	Create(name string, timestamp string) models.View
+	Create(name string, timestamp string) (models.View, error)
 
 	// Load retrieves a view by its name.
 	// Returns the loaded View or an empty View if not found.
-	Load(name string) models.View
+	Load(name string) (models.View, error)
 
 	// List returns all currently stored views.
-	List() []models.View
+	List() ([]models.View, error)
 
 	// Save persists updates to a view identified by its name.
 	// Returns the updated View.
-	Save(name string) models.View
+	Save(name string, view models.View) (models.View, error)
 
 	// Delete removes the view identified by name from the store.
 	// Returns the deleted View.
-	Delete(name string) models.View
+	Delete(name string) (models.View, error)
 }

--- a/core/store/local/local_store.go
+++ b/core/store/local/local_store.go
@@ -1,0 +1,190 @@
+package local
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/shinzonetwork/view-creator/core/models"
+	"github.com/shinzonetwork/view-creator/core/store"
+)
+
+type LocalStore struct {
+	BasePath string
+}
+
+func NewLocalStore() (*LocalStore, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("unable to get home directory: %w", err)
+	}
+
+	base := filepath.Join(home, ".shinzo", "views")
+	if err := os.MkdirAll(base, 0755); err != nil {
+		return nil, fmt.Errorf("unable to create base directory: %w", err)
+	}
+
+	return &LocalStore{BasePath: base}, nil
+}
+
+func (s *LocalStore) Create(name string, timestamp string) (models.View, error) {
+	// Create a new view folder with the name
+	folderBasePath := filepath.Join(s.BasePath, name)
+
+	// Check if the folder already exists
+	if _, err := os.Stat(folderBasePath); err == nil {
+		// Folder exists
+		return models.View{}, store.ErrViewDoesNotExist
+	} else if !os.IsNotExist(err) {
+		// Some other unexpected error
+		return models.View{}, fmt.Errorf("failed to check if view exists: %w", err)
+	}
+
+	if err := os.MkdirAll(folderBasePath, 0755); err != nil {
+		return models.View{}, fmt.Errorf("failed to create view dir: %w", err)
+	}
+
+	// Create assets subdirectory in the new view folder
+	assetsDir := filepath.Join(folderBasePath, "assets")
+	if err := os.MkdirAll(assetsDir, 0755); err != nil {
+		return models.View{}, fmt.Errorf("failed to create assets dir: %w", err)
+	}
+
+	view := models.View{
+		Name:  name,
+		Query: nil,
+		Sdl:   nil,
+		Transform: models.Transform{
+			Lenses: []models.Lens{},
+		},
+		Metadata: models.Metadata{
+			Version:   0,
+			Total:     0,
+			Revisions: []models.Revision{},
+			CreatedAt: timestamp,
+			UpdatedAt: timestamp,
+		},
+	}
+
+	// create view file in the new folder dir
+	viewFilePath := filepath.Join(folderBasePath, "view.json")
+
+	file, err := os.Create(viewFilePath)
+	if err != nil {
+		return models.View{}, fmt.Errorf("failed to create view.json: %w", err)
+	}
+	defer file.Close()
+
+	// insert view json into view file
+	if err := json.NewEncoder(file).Encode(view); err != nil {
+		return models.View{}, fmt.Errorf("failed to write JSON: %w", err)
+	}
+
+	return view, nil
+}
+
+func (s *LocalStore) Load(name string) (models.View, error) {
+	folderBasePath := filepath.Join(s.BasePath, name)
+
+	if _, err := os.Stat(folderBasePath); os.IsNotExist(err) {
+		return models.View{}, store.ErrViewDoesNotExist
+	} else if err != nil {
+		return models.View{}, fmt.Errorf("failed to check if view exists: %w", err)
+	}
+
+	viewFilePath := filepath.Join(folderBasePath, "view.json")
+
+	data, err := os.ReadFile(viewFilePath)
+	if err != nil {
+		return models.View{}, fmt.Errorf("failed to retrieve view.json file: %w", err)
+	}
+
+	var view models.View
+	if err := json.Unmarshal([]byte(data), &view); err != nil {
+		return models.View{}, fmt.Errorf("failed to unmarshall view.json file: %w", err)
+	}
+
+	return view, nil
+}
+
+func (s *LocalStore) List() ([]models.View, error) {
+	entries, err := os.ReadDir(s.BasePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read views directory: %w", err)
+	}
+
+	var views []models.View
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		viewFilePath := filepath.Join(s.BasePath, entry.Name(), "view.json")
+
+		file, err := os.Open(viewFilePath)
+		if err != nil {
+			continue
+		}
+		defer file.Close()
+
+		var view models.View
+		if err := json.NewDecoder(file).Decode(&view); err != nil {
+			continue
+		}
+
+		views = append(views, view)
+	}
+
+	return views, nil
+}
+
+func (s *LocalStore) Save(name string, view models.View) (models.View, error) {
+	folderBasePath := filepath.Join(s.BasePath, name)
+
+	// Check if view folder exists
+	if _, err := os.Stat(folderBasePath); os.IsNotExist(err) {
+		return models.View{}, store.ErrViewDoesNotExist
+	} else if err != nil {
+		return models.View{}, fmt.Errorf("failed to check if view exists: %w", err)
+	}
+
+	viewFilePath := filepath.Join(folderBasePath, "view.json")
+	tempFilePath := filepath.Join(folderBasePath, "view.tmp.json")
+
+	// Create temp file
+	file, err := os.OpenFile(tempFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return models.View{}, fmt.Errorf("failed to create temp file: %w", err)
+	}
+	defer file.Close()
+
+	// Write to temp file
+	if err := json.NewEncoder(file).Encode(view); err != nil {
+		return models.View{}, fmt.Errorf("failed to encode view to temp file: %w", err)
+	}
+
+	// Rename temp file to view.json (atomic move)
+	if err := os.Rename(tempFilePath, viewFilePath); err != nil {
+		return models.View{}, fmt.Errorf("failed to replace view.json: %w", err)
+	}
+
+	return view, nil
+}
+
+func (s *LocalStore) Delete(name string) error {
+	folderBasePath := filepath.Join(s.BasePath, name)
+
+	if _, err := os.Stat(folderBasePath); os.IsNotExist(err) {
+		return store.ErrViewDoesNotExist
+	} else if err != nil {
+		return fmt.Errorf("failed to check if view exists: %w", err)
+	}
+
+	if err := os.RemoveAll(folderBasePath); err != nil {
+		return fmt.Errorf("failed to delete view: %w", err)
+	}
+
+	return nil
+}

--- a/core/store/local/local_store.go
+++ b/core/store/local/local_store.go
@@ -14,13 +14,19 @@ type LocalStore struct {
 	BasePath string
 }
 
-func NewLocalStore() (*LocalStore, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return nil, fmt.Errorf("unable to get home directory: %w", err)
+func NewLocalStore(path string) (*LocalStore, error) {
+	var base string
+
+	if path == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("unable to get home directory: %w", err)
+		}
+		base = filepath.Join(home, ".shinzo", "views")
+	} else {
+		base = filepath.Join(path, ".shinzo", "views")
 	}
 
-	base := filepath.Join(home, ".shinzo", "views")
 	if err := os.MkdirAll(base, 0755); err != nil {
 		return nil, fmt.Errorf("unable to create base directory: %w", err)
 	}
@@ -35,7 +41,7 @@ func (s *LocalStore) Create(name string, timestamp string) (models.View, error) 
 	// Check if the folder already exists
 	if _, err := os.Stat(folderBasePath); err == nil {
 		// Folder exists
-		return models.View{}, store.ErrViewDoesNotExist
+		return models.View{}, store.ErrViewAlreadyExist
 	} else if !os.IsNotExist(err) {
 		// Some other unexpected error
 		return models.View{}, fmt.Errorf("failed to check if view exists: %w", err)

--- a/core/store/local/local_store_test.go
+++ b/core/store/local/local_store_test.go
@@ -1,0 +1,363 @@
+package local_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/shinzonetwork/view-creator/core/models"
+	"github.com/shinzonetwork/view-creator/core/store"
+	"github.com/shinzonetwork/view-creator/core/store/local"
+)
+
+func TestLocalStoreInitCreateDir(t *testing.T) {
+	temp := t.TempDir()
+
+	store, err := local.NewLocalStore(temp)
+	if err != nil {
+		t.Fatalf("failed to initialize store: %v", err)
+	}
+
+	expected := filepath.Join(temp, ".shinzo", "views")
+
+	info, err := os.Stat(expected)
+	if err != nil {
+		t.Fatalf("expected dir %s to exist, got error: %v", expected, err)
+	}
+
+	if !info.IsDir() {
+		t.Fatalf("expected %s to be a directory", expected)
+	}
+
+	_ = store
+}
+
+func TestLocalStoreCreateViewDir(t *testing.T) {
+	temp := t.TempDir()
+
+	store, err := local.NewLocalStore(temp)
+	if err != nil {
+		t.Fatalf("failed to initialize store: %v", err)
+	}
+
+	name := "testexample"
+	timestamp := "1750696562"
+
+	_, err = store.Create(name, timestamp)
+	if err != nil {
+		t.Fatalf("failed to create view: %v", err)
+	}
+
+	base := filepath.Join(temp, ".shinzo", "views", name)
+
+	// 1. Check view folder
+	if stat, err := os.Stat(base); err != nil || !stat.IsDir() {
+		t.Fatalf("expected view dir at %s, got err: %v", base, err)
+	}
+
+	// 2. Check view.json file
+	viewJSON := filepath.Join(base, "view.json")
+	if stat, err := os.Stat(viewJSON); err != nil || stat.IsDir() {
+		t.Fatalf("expected view.json file at %s, got err: %v", viewJSON, err)
+	}
+
+	// 3. Check assets directory
+	assets := filepath.Join(base, "assets")
+	if stat, err := os.Stat(assets); err != nil || !stat.IsDir() {
+		t.Fatalf("expected assets dir at %s, got err: %v", assets, err)
+	}
+
+	// validate contents of view.json
+	data, err := os.ReadFile(viewJSON)
+	if err != nil {
+		t.Fatalf("failed to read view.json: %v", err)
+	}
+
+	var view models.View
+	if err := json.Unmarshal(data, &view); err != nil {
+		t.Fatalf("failed to unmarshal view.json: %v", err)
+	}
+
+	// Validate fields
+	if view.Name != name {
+		t.Errorf("expected view name %q, got %q", name, view.Name)
+	}
+
+	if view.Metadata.CreatedAt != timestamp {
+		t.Errorf("expected createdAt %q, got %q", timestamp, view.Metadata.CreatedAt)
+	}
+
+	if view.Metadata.UpdatedAt != timestamp {
+		t.Errorf("expected updatedAt %q, got %q", timestamp, view.Metadata.UpdatedAt)
+	}
+}
+
+func TestLocalStoreCreateDuplicate(t *testing.T) {
+	temp := t.TempDir()
+
+	localstore, err := local.NewLocalStore(temp)
+	if err != nil {
+		t.Fatalf("failed to initialize store: %v", err)
+	}
+
+	name := "dupe-view"
+	timestamp := "1750696562"
+
+	// First creation should succeed
+	if _, err := localstore.Create(name, timestamp); err != nil {
+		t.Fatalf("failed to create first view: %v", err)
+	}
+
+	// Second creation with the same name should fail
+	_, err = localstore.Create(name, timestamp)
+	if err == nil {
+		t.Fatalf("expected error when creating duplicate view, got nil")
+	}
+
+	if err != store.ErrViewAlreadyExist {
+		t.Errorf("expected ErrViewAlreadyExists, got: %v", err)
+	}
+}
+
+func TestLocalStoreLoadViewInDir(t *testing.T) {
+	temp := t.TempDir()
+
+	localstore, err := local.NewLocalStore(temp)
+	if err != nil {
+		t.Fatalf("failed to initialize store: %v", err)
+	}
+
+	name := "testexample"
+	timestamp := "1750696562"
+
+	_, err = localstore.Create(name, timestamp)
+	if err != nil {
+		t.Fatalf("failed to create view: %v", err)
+	}
+
+	view, err := localstore.Load(name)
+	if err != nil {
+		t.Fatalf("failed to create load view: %v", err)
+	}
+
+	// Validate fields
+	if view.Name != name {
+		t.Errorf("expected view name %q, got %q", name, view.Name)
+	}
+
+	if view.Metadata.CreatedAt != timestamp {
+		t.Errorf("expected createdAt %q, got %q", timestamp, view.Metadata.CreatedAt)
+	}
+
+	if view.Metadata.UpdatedAt != timestamp {
+		t.Errorf("expected updatedAt %q, got %q", timestamp, view.Metadata.UpdatedAt)
+	}
+}
+
+func TestLocalStoreShouldNotLoadViewThatDontExists(t *testing.T) {
+	temp := t.TempDir()
+
+	localstore, err := local.NewLocalStore(temp)
+	if err != nil {
+		t.Fatalf("failed to initialize store: %v", err)
+	}
+
+	name := "testexample"
+
+	// load should return error because view does not exist
+	_, err = localstore.Load(name)
+	if err == nil {
+		t.Fatalf("expected error when loading not exisitng view, got nil")
+	}
+
+	if err != store.ErrViewDoesNotExist {
+		t.Errorf("expected ErrViewDoesNotExist, got: %v", err)
+	}
+}
+
+func TestLocalStoreDeleteRemovesViewDir(t *testing.T) {
+	temp := t.TempDir()
+
+	localstore, err := local.NewLocalStore(temp)
+	if err != nil {
+		t.Fatalf("failed to initialize store: %v", err)
+	}
+
+	name := "testexample"
+	timestamp := "1750696562"
+
+	_, err = localstore.Create(name, timestamp)
+	if err != nil {
+		t.Fatalf("failed to create view: %v", err)
+	}
+
+	// Delete it
+	if err := localstore.Delete(name); err != nil {
+		t.Fatalf("failed to delete view: %v", err)
+	}
+
+	// Assert folder is gone
+	deletedPath := filepath.Join(temp, ".shinzo", "views", name)
+	if _, err := os.Stat(deletedPath); !os.IsNotExist(err) {
+		t.Errorf("expected view folder to be deleted, but it still exists: %v", err)
+	}
+}
+
+func TestLocalStoreDeleteNonExistentView(t *testing.T) {
+	temp := t.TempDir()
+
+	localstore, err := local.NewLocalStore(temp)
+	if err != nil {
+		t.Fatalf("failed to initialize store: %v", err)
+	}
+
+	err = localstore.Delete("testexample")
+	if err == nil {
+		t.Fatal("expected error when deleting non-existent view, got nil")
+	}
+
+	if err != store.ErrViewDoesNotExist {
+		t.Errorf("expected ErrViewDoesNotExist, got: %v", err)
+	}
+}
+
+func TestLocalStoreListReturnsCreatedViews(t *testing.T) {
+	temp := t.TempDir()
+
+	localstore, err := local.NewLocalStore(temp)
+	if err != nil {
+		t.Fatalf("failed to initialize store: %v", err)
+	}
+
+	viewsToCreate := []string{"alpha", "beta", "gamma"}
+
+	for _, name := range viewsToCreate {
+		_, err := localstore.Create(name, "1750696562")
+		if err != nil {
+			t.Fatalf("failed to create view %s: %v", name, err)
+		}
+	}
+
+	views, err := localstore.List()
+	if err != nil {
+		t.Fatalf("failed to list views: %v", err)
+	}
+
+	if len(views) != len(viewsToCreate) {
+		t.Errorf("expected %d views, got %d", len(viewsToCreate), len(views))
+	}
+
+	names := map[string]bool{}
+	for _, v := range views {
+		names[v.Name] = true
+	}
+
+	for _, name := range viewsToCreate {
+		if !names[name] {
+			t.Errorf("expected view %q to be in list, but it wasn't", name)
+		}
+	}
+}
+
+func TestLocalStoreSaveUpdatesViewJson(t *testing.T) {
+	temp := t.TempDir()
+	store, err := local.NewLocalStore(temp)
+	if err != nil {
+		t.Fatalf("failed to initialize store: %v", err)
+	}
+
+	name := "testexample"
+	timestamp := "1750696562"
+
+	original, err := store.Create(name, timestamp)
+	if err != nil {
+		t.Fatalf("failed to create view: %v", err)
+	}
+
+	// Use the provided query and SDL
+	original.Query = String("Log {address topics data transactionHash blockNumber}")
+	original.Sdl = String("type FilteredAndDecodedLogs @materialized(if: false) {hash: String block: String address: String signature: String }")
+
+	_, err = store.Save(name, original)
+	if err != nil {
+		t.Fatalf("failed to save updated view: %v", err)
+	}
+
+	// Load it back from disk
+	loaded, err := store.Load(name)
+	if err != nil {
+		t.Fatalf("failed to load saved view: %v", err)
+	}
+
+	if loaded.Query == nil || *loaded.Query != *original.Query {
+		t.Errorf("expected Query to be %q, got: %v", *original.Query, *loaded.Query)
+	}
+
+	if loaded.Sdl == nil || *loaded.Sdl != *original.Sdl {
+		t.Errorf("expected Sdl to be %q, got: %v", *original.Sdl, *loaded.Sdl)
+	}
+}
+
+func TestLocalStoreLifecycle(t *testing.T) {
+	temp := t.TempDir()
+	localstore, err := local.NewLocalStore(temp)
+	if err != nil {
+		t.Fatalf("failed to initialize store: %v", err)
+	}
+
+	name := "fulltest"
+	timestamp := "1750696562"
+
+	// 1. Create
+	view, err := localstore.Create(name, timestamp)
+	if err != nil {
+		t.Fatalf("failed to create view: %v", err)
+	}
+
+	// 2. Update and Save
+	view.Query = String("query { field }")
+	view.Sdl = String("type T { field: String }")
+	_, err = localstore.Save(name, view)
+	if err != nil {
+		t.Fatalf("failed to save view: %v", err)
+	}
+
+	// 3. Load
+	loaded, err := localstore.Load(name)
+	if err != nil {
+		t.Fatalf("failed to load view: %v", err)
+	}
+
+	if loaded.Query == nil || *loaded.Query != *view.Query {
+		t.Errorf("expected Query %q, got %v", *view.Query, loaded.Query)
+	}
+	if loaded.Sdl == nil || *loaded.Sdl != *view.Sdl {
+		t.Errorf("expected Sdl %q, got %v", *view.Sdl, loaded.Sdl)
+	}
+
+	// 4. List
+	listed, err := localstore.List()
+	if err != nil {
+		t.Fatalf("failed to list views: %v", err)
+	}
+	if len(listed) != 1 || listed[0].Name != name {
+		t.Errorf("expected list to contain %q, got %+v", name, listed)
+	}
+
+	// 5. Delete
+	err = localstore.Delete(name)
+	if err != nil {
+		t.Fatalf("failed to delete view: %v", err)
+	}
+
+	// 6. Confirm Deletion
+	_, err = localstore.Load(name)
+	if err != store.ErrViewDoesNotExist {
+		t.Errorf("expected ErrViewDoesNotExist after delete, got %v", err)
+	}
+}
+
+func String(s string) *string {
+	return &s
+}


### PR DESCRIPTION
# Add `LocalStore` Implementation for View Persistence

## Summary

This PR introduces a new `LocalStore` module that satisfies the `ViewStore` interface. It enables reliable local persistence of views to disk using a structured directory format.

## Key Features

- Implements `LocalStore` as a local file-based backend for view storage  
- Stores views at `.shinzo/views/<name>/view.json`  
- Automatically creates required directories on initialization or view creation  
- Uses atomic save — writes to a temp file before renaming to `view.json`  
- Fully supports all `ViewStore` interface methods:
  - `Create(name string, view *View) error`: Initializes the directory and saves the view
  - `Save(name string, view *View) error`: Atomically writes updated view content
  - `Load(name string) (*View, error)`: Loads view data from disk and unmarshals it
  - `Delete(name string) error`: Deletes the entire view directory
  - `List() ([]string, error)`: Lists all existing view names under `.shinzo/views`