### PR TITLE
Feat/cli/mutation

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,0 +1,14 @@
+package cli
+
+import "github.com/spf13/cobra"
+
+func NewViewCreatorCommand() *cobra.Command {
+	view := MakeViewCommand()
+
+	root := MakeRootCommand()
+	root.AddCommand(
+		view,
+	)
+
+	return root
+}

--- a/cli/root.go
+++ b/cli/root.go
@@ -1,0 +1,16 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func MakeRootCommand() *cobra.Command {
+	var cmd = &cobra.Command{
+		SilenceUsage: true,
+		Use:          "viewkit",
+		Short:        "A CLI tool to manage shinzo views",
+		Long:         "Viewkit helps you initialize, manage, and publish Shinzo views through a simple CLI interface.",
+	}
+
+	return cmd
+}

--- a/cli/util.go
+++ b/cli/util.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"strconv"
+	"time"
 
 	"github.com/shinzonetwork/view-creator/core/models"
 	"github.com/shinzonetwork/view-creator/core/store"
@@ -111,11 +113,14 @@ func printViewPretty(cmd *cobra.Command, view models.View, verbose bool, jsonOut
 	}
 	cmd.Println()
 
+	createdAt, _ := strconv.ParseInt(view.Metadata.CreatedAt, 10, 64)
+	updatedAt, _ := strconv.ParseInt(view.Metadata.UpdatedAt, 10, 64)
+
 	cmd.Printf("🗂  Metadata:\n - Version: %d\n - Total: %d\n - Created At: %s\n - Updated At: %s\n",
 		view.Metadata.Version,
 		view.Metadata.Total,
-		view.Metadata.CreatedAt,
-		view.Metadata.UpdatedAt,
+		time.Unix(createdAt, 0).UTC(),
+		time.Unix(updatedAt, 0).UTC(),
 	)
 
 	if verbose && len(view.Metadata.Revisions) > 0 {

--- a/cli/util.go
+++ b/cli/util.go
@@ -1,0 +1,123 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/shinzonetwork/view-creator/core/models"
+	"github.com/shinzonetwork/view-creator/core/store"
+	"github.com/shinzonetwork/view-creator/core/store/local"
+	"github.com/spf13/cobra"
+)
+
+type contextKey string
+
+var (
+	storeContextKey = contextKey("store")
+)
+
+func mustGetContextStore(cmd *cobra.Command) store.ViewStore {
+	return cmd.Context().Value(storeContextKey).(store.ViewStore)
+}
+
+func setContextStore(cmd *cobra.Command) error {
+	store, err := local.NewLocalStore()
+	if err != nil {
+		return err
+	}
+	ctx := context.WithValue(cmd.Context(), storeContextKey, store)
+	cmd.SetContext(ctx)
+	return nil
+}
+
+func printViewPretty(cmd *cobra.Command, view models.View, verbose bool, jsonOutput bool) {
+	if jsonOutput {
+		var output any
+		if verbose {
+			output = view
+		} else {
+			output = struct {
+				Name      string           `json:"name"`
+				Query     *string          `json:"query"`
+				Sdl       *string          `json:"sdl"`
+				Transform models.Transform `json:"transform"`
+				Metadata  struct {
+					Version   int    `json:"_v"`
+					Total     int    `json:"_t"`
+					CreatedAt string `json:"createdAt"`
+					UpdatedAt string `json:"updatedAt"`
+				} `json:"metadata"`
+			}{
+				Name:      view.Name,
+				Query:     view.Query,
+				Sdl:       view.Sdl,
+				Transform: view.Transform,
+				Metadata: struct {
+					Version   int    `json:"_v"`
+					Total     int    `json:"_t"`
+					CreatedAt string `json:"createdAt"`
+					UpdatedAt string `json:"updatedAt"`
+				}{
+					Version:   view.Metadata.Version,
+					Total:     view.Metadata.Total,
+					CreatedAt: view.Metadata.CreatedAt,
+					UpdatedAt: view.Metadata.UpdatedAt,
+				},
+			}
+		}
+
+		encoded, err := json.MarshalIndent(output, "", "  ")
+		if err != nil {
+			cmd.Printf("❌ Failed to encode view: %v\n", err)
+			return
+		}
+		cmd.Println(string(encoded))
+		return
+	}
+
+	// === Pretty Output ===
+
+	cmd.Printf("📄 View: %s\n", view.Name)
+
+	if view.Query != nil && *view.Query != "" {
+		cmd.Printf("🔍 Query:\n%s\n\n", *view.Query)
+	} else {
+		cmd.Println("🔍 Query: <none>")
+	}
+
+	if view.Sdl != nil && *view.Sdl != "" {
+		cmd.Printf("📐 SDL:\n%s\n\n", *view.Sdl)
+	} else {
+		cmd.Println("📐 SDL: <none>")
+	}
+
+	cmd.Println("🔧 Lenses:")
+	if len(view.Transform.Lenses) == 0 {
+		cmd.Println(" - (empty)")
+	} else {
+		for _, lens := range view.Transform.Lenses {
+			cmd.Printf(" - %s (%s)\n", lens.Label, lens.Path)
+			if len(lens.Arguments) > 0 {
+				cmd.Println("   Arguments:")
+				for k, v := range lens.Arguments {
+					cmd.Printf("     %s: %v\n", k, v)
+				}
+			}
+		}
+	}
+	cmd.Println()
+
+	cmd.Printf("🗂  Metadata:\n - Version: %d\n - Total: %d\n - Created At: %s\n - Updated At: %s\n",
+		view.Metadata.Version,
+		view.Metadata.Total,
+		view.Metadata.CreatedAt,
+		view.Metadata.UpdatedAt,
+	)
+
+	if verbose && len(view.Metadata.Revisions) > 0 {
+		cmd.Printf("📝 Revisions (%d):\n", len(view.Metadata.Revisions))
+		for i, rev := range view.Metadata.Revisions {
+			cmd.Printf(" - Revision %d:\n   %s\n", i+1, rev.Diff)
+		}
+	}
+}

--- a/cli/util.go
+++ b/cli/util.go
@@ -30,6 +30,10 @@ func setContextStore(cmd *cobra.Command) error {
 	return nil
 }
 
+func WithStore(ctx context.Context, s store.ViewStore) context.Context {
+	return context.WithValue(ctx, storeContextKey, s)
+}
+
 func printViewPretty(cmd *cobra.Command, view models.View, verbose bool, jsonOutput bool) {
 	if jsonOutput {
 		var output any

--- a/cli/view.go
+++ b/cli/view.go
@@ -1,0 +1,25 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func MakeViewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "view",
+		Short: "Commands for working with views",
+		Long:  "Use this command group to create, delete, and manage views in Viewkit.",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) (err error) {
+			if err := setContextStore(cmd); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
+	cmd.AddCommand(MakeViewInitCommand())
+	cmd.AddCommand(MakeViewDeleteCommand())
+	cmd.AddCommand(MakeViewInspectCommand())
+
+	return cmd
+}

--- a/cli/view.go
+++ b/cli/view.go
@@ -20,6 +20,7 @@ func MakeViewCommand() *cobra.Command {
 	cmd.AddCommand(MakeViewInitCommand())
 	cmd.AddCommand(MakeViewDeleteCommand())
 	cmd.AddCommand(MakeViewInspectCommand())
+	cmd.AddCommand(MakeViewAddCommand())
 
 	return cmd
 }

--- a/cli/view_add.go
+++ b/cli/view_add.go
@@ -26,8 +26,8 @@ func MakeViewAddCommand() *cobra.Command {
 
 	cmd.PersistentFlags().StringVar(&viewName, "name", "", "Name of the view")
 
-	cmd.AddCommand(makeAddQueryCommand(&viewName))
-	cmd.AddCommand(makeAddSdlCommand(&viewName))
+	cmd.AddCommand(MakeAddQueryCommand(&viewName))
+	cmd.AddCommand(MakeAddSdlCommand(&viewName))
 	cmd.AddCommand(MakeAddLensCommand(&viewName))
 
 	return cmd

--- a/cli/view_add.go
+++ b/cli/view_add.go
@@ -1,0 +1,34 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func MakeViewAddCommand() *cobra.Command {
+	var viewName string
+
+	cmd := &cobra.Command{
+		Use:   "add",
+		Short: "Add components to an existing view",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := setContextStore(cmd); err != nil {
+				return err
+			}
+
+			if viewName == "" {
+				return fmt.Errorf("view name is required (use --name)")
+			}
+			return nil
+		},
+	}
+
+	cmd.PersistentFlags().StringVar(&viewName, "name", "", "Name of the view")
+
+	cmd.AddCommand(makeAddQueryCommand(&viewName))
+	cmd.AddCommand(makeAddSdlCommand(&viewName))
+	cmd.AddCommand(MakeAddLensCommand(&viewName))
+
+	return cmd
+}

--- a/cli/view_add_lens.go
+++ b/cli/view_add_lens.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/shinzonetwork/view-creator/core/service"
+	"github.com/spf13/cobra"
+)
+
+func MakeAddLensCommand(viewName *string) *cobra.Command {
+	var wasmPath string
+	var wasmURL string
+	var argsJson string
+	var label string
+
+	cmd := &cobra.Command{
+		Use:   "lens",
+		Short: "Manage lenses in a view",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var path string
+
+			if wasmURL != "" {
+				path = wasmURL
+			} else if wasmPath != "" {
+				path = wasmPath
+			} else {
+				return fmt.Errorf("either --path or --url must be provided")
+			}
+
+			if label == "" {
+				return fmt.Errorf("--label is required")
+			}
+
+			var argsMap map[string]any
+			if argsJson != "" {
+				if err := json.Unmarshal([]byte(argsJson), &argsMap); err != nil {
+					return fmt.Errorf("invalid --args JSON: %w", err)
+				}
+			}
+
+			store := mustGetContextStore(cmd)
+
+			// function to add lens
+			view, err := service.InitLens(*viewName, label, path, argsMap, store)
+			if err != nil {
+				return err
+			}
+
+			printViewPretty(cmd, view, false, false)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&label, "label", "", "name of lens")
+	cmd.Flags().StringVar(&wasmPath, "path", "", "Path to the WASM file (local)")
+	cmd.Flags().StringVar(&wasmURL, "url", "", "URL to download the WASM file from")
+	cmd.Flags().StringVar(&argsJson, "args", "", "arguments of the lens transform")
+
+	return cmd
+}

--- a/cli/view_add_lens.go
+++ b/cli/view_add_lens.go
@@ -16,7 +16,7 @@ func MakeAddLensCommand(viewName *string) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "lens",
-		Short: "Manage lenses in a view",
+		Short: "Add lenses in a view",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var path string
 

--- a/cli/view_add_lens_test.go
+++ b/cli/view_add_lens_test.go
@@ -1,0 +1,79 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/shinzonetwork/view-creator/cli"
+	"github.com/shinzonetwork/view-creator/core/store/local"
+)
+
+func TestAddLensToExistingView(t *testing.T) {
+	tempDir := t.TempDir()
+
+	store, err := local.NewLocalStore(tempDir)
+	if err != nil {
+		t.Fatalf("failed to create temp store: %v", err)
+	}
+
+	viewName := "testview"
+
+	cmd := cli.MakeViewInitCommand()
+	cmd.SetArgs([]string{viewName})
+
+	var initBuf bytes.Buffer
+	cmd.SetOut(&initBuf)
+	cmd.SetErr(&initBuf)
+	cmd.SetContext(cli.WithStore(context.Background(), store))
+
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("view init command failed: %v", err)
+	}
+
+	wasmPath := filepath.Join(tempDir, "decode_usdt.wasm")
+	if err := os.WriteFile(wasmPath, []byte("\x00asm\x01\x00\x00\x00"), 0644); err != nil {
+		t.Fatalf("failed to write dummy wasm: %v", err)
+	}
+
+	cmd = cli.MakeAddLensCommand(&viewName)
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{
+		"--label", "decode_usdt",
+		"--path", wasmPath,
+		"--args", `{"token": "USDT", "decimals": 6}`,
+	})
+	cmd.SetContext(cli.WithStore(context.Background(), store))
+
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("add lens command failed: %v", err)
+	}
+
+	out := buf.String()
+
+	expected := `📄 View: testview
+🔍 Query: <none>
+📐 SDL: <none>
+🔧 Lenses:
+ - decode_usdt (assets/decode_usdt.wasm)
+   Arguments:
+     token: USDT
+     decimals: 6
+
+🗂  Metadata:
+ - Version: 0
+ - Total: 0
+ - Created At: `
+
+	if !strings.HasPrefix(out, expected) {
+		t.Errorf("unexpected output.\nGot:\n%s\nExpected prefix:\n%s", out, expected)
+	}
+}

--- a/cli/view_add_query.go
+++ b/cli/view_add_query.go
@@ -5,7 +5,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func makeAddQueryCommand(viewName *string) *cobra.Command {
+func MakeAddQueryCommand(viewName *string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "query '<query>'",
 		Short: "Add or update the query of the view",

--- a/cli/view_add_query.go
+++ b/cli/view_add_query.go
@@ -1,0 +1,25 @@
+package cli
+
+import (
+	"github.com/shinzonetwork/view-creator/core/service"
+	"github.com/spf13/cobra"
+)
+
+func makeAddQueryCommand(viewName *string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "query '<query>'",
+		Short: "Add or update the query of the view",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store := mustGetContextStore(cmd)
+			view, err := service.UpdateQuery(*viewName, args[0], store)
+			if err != nil {
+				return err
+			}
+
+			printViewPretty(cmd, view, false, false)
+
+			return nil
+		},
+	}
+}

--- a/cli/view_add_query_test.go
+++ b/cli/view_add_query_test.go
@@ -1,0 +1,140 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/shinzonetwork/view-creator/cli"
+	"github.com/shinzonetwork/view-creator/core/store/local"
+)
+
+func TestAddQueryToExistingView(t *testing.T) {
+	tempDir := t.TempDir()
+
+	store, err := local.NewLocalStore(tempDir)
+	if err != nil {
+		t.Fatalf("failed to create temp store: %v", err)
+	}
+
+	viewName := "testview"
+
+	cmd := cli.MakeViewInitCommand()
+	cmd.SetArgs([]string{viewName})
+
+	var initBuf bytes.Buffer
+	cmd.SetOut(&initBuf)
+	cmd.SetErr(&initBuf)
+	cmd.SetContext(cli.WithStore(context.Background(), store))
+
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("command failed: %v", err)
+	}
+
+	query := `Log {address topics data transactionHash blockNumber}`
+
+	cmd = cli.MakeAddQueryCommand(&viewName)
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{query})
+	cmd.SetContext(cli.WithStore(context.Background(), store))
+
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("add query command failed: %v", err)
+	}
+
+	out := buf.String()
+
+	expected := `📄 View: testview
+🔍 Query:
+Log {address topics data transactionHash blockNumber}
+
+📐 SDL: <none>
+🔧 Lenses:
+ - (empty)
+
+🗂  Metadata:
+ - Version: 0
+ - Total: 0
+ - Created At: `
+
+	if !strings.HasPrefix(out, expected) {
+		t.Errorf("unexpected output.\nGot:\n%s\nExpected prefix:\n%s", out, expected)
+	}
+}
+
+func TestUpdateQueryOfExistingView(t *testing.T) {
+	tempDir := t.TempDir()
+
+	store, err := local.NewLocalStore(tempDir)
+	if err != nil {
+		t.Fatalf("failed to create temp store: %v", err)
+	}
+
+	viewName := "testview"
+
+	cmd := cli.MakeViewInitCommand()
+	cmd.SetArgs([]string{viewName})
+
+	var initBuf bytes.Buffer
+	cmd.SetOut(&initBuf)
+	cmd.SetErr(&initBuf)
+	cmd.SetContext(cli.WithStore(context.Background(), store))
+
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("command failed: %v", err)
+	}
+
+	initialQuery := `Log {address}`
+	cmd = cli.MakeAddQueryCommand(&viewName)
+
+	var firstBuf bytes.Buffer
+	cmd.SetOut(&firstBuf)
+	cmd.SetErr(&firstBuf)
+	cmd.SetArgs([]string{initialQuery})
+	cmd.SetContext(cli.WithStore(context.Background(), store))
+
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("add initial query command failed: %v", err)
+	}
+
+	updatedQuery := `Log {address topics data transactionHash blockNumber}`
+	cmd = cli.MakeAddQueryCommand(&viewName)
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{updatedQuery})
+	cmd.SetContext(cli.WithStore(context.Background(), store))
+
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("update query command failed: %v", err)
+	}
+
+	out := buf.String()
+
+	expected := `📄 View: testview
+🔍 Query:
+Log {address topics data transactionHash blockNumber}
+
+📐 SDL: <none>
+🔧 Lenses:
+ - (empty)
+
+🗂  Metadata:
+ - Version: 0
+ - Total: 0
+ - Created At: `
+
+	if !strings.HasPrefix(out, expected) {
+		t.Errorf("unexpected output.\nGot:\n%s\nExpected prefix:\n%s", out, expected)
+	}
+}

--- a/cli/view_add_sdl.go
+++ b/cli/view_add_sdl.go
@@ -1,0 +1,25 @@
+package cli
+
+import (
+	"github.com/shinzonetwork/view-creator/core/service"
+	"github.com/spf13/cobra"
+)
+
+func makeAddSdlCommand(viewName *string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "sdl '<sdl>'",
+		Short: "Add or update the sdl of the view",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store := mustGetContextStore(cmd)
+			view, err := service.UpdateSDL(*viewName, args[0], store)
+			if err != nil {
+				return err
+			}
+
+			printViewPretty(cmd, view, false, false)
+
+			return nil
+		},
+	}
+}

--- a/cli/view_add_sdl.go
+++ b/cli/view_add_sdl.go
@@ -5,7 +5,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func makeAddSdlCommand(viewName *string) *cobra.Command {
+func MakeAddSdlCommand(viewName *string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "sdl '<sdl>'",
 		Short: "Add or update the sdl of the view",

--- a/cli/view_add_sdl_test.go
+++ b/cli/view_add_sdl_test.go
@@ -1,0 +1,144 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/shinzonetwork/view-creator/cli"
+	"github.com/shinzonetwork/view-creator/core/store/local"
+)
+
+func TestAddSdlToExistingView(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create local store
+	store, err := local.NewLocalStore(tempDir)
+	if err != nil {
+		t.Fatalf("failed to create temp store: %v", err)
+	}
+
+	viewName := "testview"
+
+	cmd := cli.MakeViewInitCommand()
+	cmd.SetArgs([]string{viewName})
+
+	var initBuf bytes.Buffer
+	cmd.SetOut(&initBuf)
+	cmd.SetErr(&initBuf)
+
+	// Inject store into context
+	ctx := cli.WithStore(context.Background(), store)
+	cmd.SetContext(ctx)
+
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("command failed: %v", err)
+	}
+
+	sdl := `type FilteredAndDecodedLogs @materialized(if: false) {hash: String block: String address: String signature: String}`
+
+	cmd = cli.MakeAddSdlCommand(&viewName)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{sdl})
+	cmd.SetContext(cli.WithStore(context.Background(), store))
+
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("add SDL command failed: %v", err)
+	}
+
+	out := buf.String()
+
+	expected := `📄 View: testview
+🔍 Query: <none>
+📐 SDL:
+type FilteredAndDecodedLogs @materialized(if: false) {hash: String block: String address: String signature: String}
+
+🔧 Lenses:
+ - (empty)
+
+🗂  Metadata:
+ - Version: 0
+ - Total: 0
+ - Created At: `
+
+	if !strings.HasPrefix(out, expected) {
+		t.Errorf("unexpected output.\nGot:\n%s\nExpected prefix:\n%s", out, expected)
+	}
+}
+
+func TestUpdateSdlOfExistingView(t *testing.T) {
+	tempDir := t.TempDir()
+
+	store, err := local.NewLocalStore(tempDir)
+	if err != nil {
+		t.Fatalf("failed to create temp store: %v", err)
+	}
+
+	viewName := "testview"
+
+	cmd := cli.MakeViewInitCommand()
+	cmd.SetArgs([]string{viewName})
+
+	var initBuf bytes.Buffer
+	cmd.SetOut(&initBuf)
+	cmd.SetErr(&initBuf)
+	cmd.SetContext(cli.WithStore(context.Background(), store))
+
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("command failed: %v", err)
+	}
+
+	initialSDL := `type FilteredAndDecodedLogs @materialized(if: false) {hash: String}`
+	cmd = cli.MakeAddSdlCommand(&viewName)
+
+	var firstBuf bytes.Buffer
+	cmd.SetOut(&firstBuf)
+	cmd.SetErr(&firstBuf)
+	cmd.SetArgs([]string{initialSDL})
+	cmd.SetContext(cli.WithStore(context.Background(), store))
+
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("add initial SDL command failed: %v", err)
+	}
+
+	updatedSDL := `type FilteredAndDecodedLogs @materialized(if: false) {hash: String block: String address: String signature: String}`
+
+	cmd = cli.MakeAddSdlCommand(&viewName)
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{updatedSDL})
+	cmd.SetContext(cli.WithStore(context.Background(), store))
+
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("update SDL command failed: %v", err)
+	}
+
+	out := buf.String()
+
+	expected := `📄 View: testview
+🔍 Query: <none>
+📐 SDL:
+type FilteredAndDecodedLogs @materialized(if: false) {hash: String block: String address: String signature: String}
+
+🔧 Lenses:
+ - (empty)
+
+🗂  Metadata:
+ - Version: 0
+ - Total: 0
+ - Created At: `
+
+	if !strings.HasPrefix(out, expected) {
+		t.Errorf("unexpected output.\nGot:\n%s\nExpected prefix:\n%s", out, expected)
+	}
+}

--- a/cli/view_delete.go
+++ b/cli/view_delete.go
@@ -8,7 +8,7 @@ import (
 func MakeViewDeleteCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete [name]",
-		Short: "Delet a saved view",
+		Short: "Delete a saved view",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			storeImpl := mustGetContextStore(cmd)

--- a/cli/view_delete.go
+++ b/cli/view_delete.go
@@ -1,0 +1,26 @@
+package cli
+
+import (
+	"github.com/shinzonetwork/view-creator/core/service"
+	"github.com/spf13/cobra"
+)
+
+func MakeViewDeleteCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete [name]",
+		Short: "Delet a saved view",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			storeImpl := mustGetContextStore(cmd)
+			err := service.DeleteView(args[0], storeImpl)
+			if err != nil {
+				return err
+			}
+
+			cmd.Printf("deleted view %s Successfully\n", args[0])
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cli/view_delete_test.go
+++ b/cli/view_delete_test.go
@@ -1,0 +1,86 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/shinzonetwork/view-creator/cli"
+	"github.com/shinzonetwork/view-creator/core/service"
+	"github.com/shinzonetwork/view-creator/core/store/local"
+	"github.com/spf13/cobra"
+)
+
+func TestDeleteViewSuccess(t *testing.T) {
+	tempDir := t.TempDir()
+	store, err := local.NewLocalStore(tempDir)
+	if err != nil {
+		t.Fatalf("failed to create local store: %v", err)
+	}
+
+	// First: create a view so we can delete it
+	view, err := service.InitView("testview", store)
+	if err != nil {
+		t.Fatalf("failed to init view: %v", err)
+	}
+	if view.Name != "testview" {
+		t.Fatalf("unexpected view name: %s", view.Name)
+	}
+
+	// Now: delete the view via CLI
+	cmd := cli.MakeViewDeleteCommand()
+	cmd.SetArgs([]string{"testview"})
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetContext(cli.WithStore(context.Background(), store))
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("delete command failed: %v", err)
+	}
+
+	out := buf.String()
+	expected := "deleted view testview Successfully"
+	if !strings.Contains(out, expected) {
+		t.Errorf("expected confirmation message, got:\n%s", out)
+	}
+}
+
+func TestDeleteViewAlreadyDeletedFails(t *testing.T) {
+	tempDir := t.TempDir()
+	store, err := local.NewLocalStore(tempDir)
+	if err != nil {
+		t.Fatalf("failed to create local store: %v", err)
+	}
+
+	// Create and delete the view first
+	if _, err := service.InitView("testview", store); err != nil {
+		t.Fatalf("failed to init view: %v", err)
+	}
+
+	deleteCmd := func() *cobra.Command {
+		cmd := cli.MakeViewDeleteCommand()
+		cmd.SetArgs([]string{"testview"})
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetErr(&bytes.Buffer{})
+		cmd.SetContext(cli.WithStore(context.Background(), store))
+		return cmd
+	}
+
+	// First delete (should succeed)
+	if err := deleteCmd().Execute(); err != nil {
+		t.Fatalf("first delete failed: %v", err)
+	}
+
+	// Second delete (should fail)
+	err = deleteCmd().Execute()
+	if err == nil {
+		t.Fatal("expected error on second delete, got none")
+	}
+
+	if !strings.Contains(err.Error(), "view does not exists") {
+		t.Errorf("expected error to mention 'not found', got: %v", err)
+	}
+}

--- a/cli/view_init.go
+++ b/cli/view_init.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"github.com/shinzonetwork/view-creator/core/service"
+	"github.com/spf13/cobra"
+)
+
+func MakeViewInitCommand() *cobra.Command {
+	var verbose bool
+	var jsonOutput bool
+
+	cmd := &cobra.Command{
+		Use:   "init [name]",
+		Short: "Initialize a new view",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			storeImpl := mustGetContextStore(cmd)
+			view, err := service.InitView(args[0], storeImpl)
+			if err != nil {
+				return err
+			}
+
+			printViewPretty(cmd, view, verbose, jsonOutput)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output the view in raw JSON format")
+	cmd.Flags().BoolVar(&verbose, "verbose", false, "Show full output including revision history")
+
+	return cmd
+}

--- a/cli/view_init_test.go
+++ b/cli/view_init_test.go
@@ -1,0 +1,94 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/shinzonetwork/view-creator/cli"
+	"github.com/shinzonetwork/view-creator/core/store/local"
+	"github.com/spf13/cobra"
+)
+
+func TestInitViewDirectWithTempStore(t *testing.T) {
+	tempDir := t.TempDir()
+
+	store, err := local.NewLocalStore(tempDir)
+	if err != nil {
+		t.Fatalf("failed to create temp store: %v", err)
+	}
+
+	cmd := cli.MakeViewInitCommand()
+
+	cmd.SetArgs([]string{"testview"})
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+
+	// Inject store into context
+	ctx := cli.WithStore(context.Background(), store)
+	cmd.SetContext(ctx)
+
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("command failed: %v", err)
+	}
+
+	out := buf.String()
+
+	expected := `📄 View: testview
+🔍 Query: <none>
+📐 SDL: <none>
+🔧 Lenses:
+ - (empty)
+
+🗂  Metadata:
+ - Version: 0
+ - Total: 0
+ - Created At: `
+
+	if !strings.Contains(out, expected) {
+		t.Errorf("expected view name in output, got:\n%s \nexpected:\n%s", out, expected)
+	}
+}
+
+func TestInitViewDuplicateFails(t *testing.T) {
+	tempDir := t.TempDir()
+	store, err := local.NewLocalStore(tempDir)
+	if err != nil {
+		t.Fatalf("failed to create temp store: %v", err)
+	}
+
+	createCmd := func() *cobra.Command {
+		cmd := cli.MakeViewInitCommand()
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetErr(&bytes.Buffer{})
+		cmd.SetContext(cli.WithStore(context.Background(), store))
+		return cmd
+	}
+
+	// First creation (should succeed)
+	cmd1 := createCmd()
+	cmd1.SetArgs([]string{"testview"})
+
+	if err := cmd1.Execute(); err != nil {
+		t.Fatalf("first creation failed unexpectedly: %v", err)
+	}
+
+	// Second creation (should fail)
+	cmd2 := createCmd()
+	cmd2.SetArgs([]string{"testview"})
+
+	err = cmd2.Execute()
+	if err == nil {
+		t.Fatal("expected second creation to fail, but it succeeded")
+	}
+
+	// Optionally check for specific error message
+	expected := "view already exists"
+	if !strings.Contains(err.Error(), expected) {
+		t.Errorf("expected error to contain %q, got: %v", expected, err)
+	}
+}

--- a/cli/view_inspect.go
+++ b/cli/view_inspect.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"github.com/shinzonetwork/view-creator/core/service"
+	"github.com/spf13/cobra"
+)
+
+func MakeViewInspectCommand() *cobra.Command {
+	var verbose bool
+	var jsonOutput bool
+
+	cmd := &cobra.Command{
+		Use:   "inspect [name]",
+		Short: "Inspect a saved view",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			storeImpl := mustGetContextStore(cmd)
+			view, err := service.InspectView(args[0], storeImpl)
+			if err != nil {
+				return err
+			}
+
+			printViewPretty(cmd, view, verbose, jsonOutput)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output the view in raw JSON format")
+	cmd.Flags().BoolVar(&verbose, "verbose", false, "Show full output including revision history")
+
+	return cmd
+}

--- a/cli/view_inspect_test.go
+++ b/cli/view_inspect_test.go
@@ -1,0 +1,82 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/shinzonetwork/view-creator/cli"
+	"github.com/shinzonetwork/view-creator/core/service"
+	"github.com/shinzonetwork/view-creator/core/store/local"
+)
+
+func TestViewInspectCommandSuccess(t *testing.T) {
+	tempDir := t.TempDir()
+	store, err := local.NewLocalStore(tempDir)
+	if err != nil {
+		t.Fatalf("failed to create local store: %v", err)
+	}
+
+	// Create the view first
+	_, err = service.InitView("testview", store)
+	if err != nil {
+		t.Fatalf("failed to initialize view: %v", err)
+	}
+
+	// Create the inspect command
+	cmd := cli.MakeViewInspectCommand()
+	cmd.SetArgs([]string{"testview"})
+
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetContext(cli.WithStore(context.Background(), store))
+
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("inspect command failed: %v", err)
+	}
+
+	output := out.String()
+
+	expected := `📄 View: testview
+🔍 Query: <none>
+📐 SDL: <none>
+🔧 Lenses:
+ - (empty)
+
+🗂  Metadata:
+ - Version: 0
+ - Total: 0
+ - Created At: `
+
+	if !strings.Contains(output, expected) {
+		t.Errorf("expected view name in output, got:\n%s \nexpected:\n%s", output, expected)
+	}
+}
+
+func TestViewInspectCommandNotFound(t *testing.T) {
+	tempDir := t.TempDir()
+	store, err := local.NewLocalStore(tempDir)
+	if err != nil {
+		t.Fatalf("failed to create local store: %v", err)
+	}
+
+	cmd := cli.MakeViewInspectCommand()
+	cmd.SetArgs([]string{"ghostview"})
+
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetContext(cli.WithStore(context.Background(), store))
+
+	err = cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when inspecting non-existent view, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "view does not exists") {
+		t.Errorf("expected 'not found' error, got: %v", err)
+	}
+}

--- a/cli/view_remove.go
+++ b/cli/view_remove.go
@@ -1,0 +1,34 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func MakeViewRemoveCommand() *cobra.Command {
+	var viewName string
+
+	cmd := &cobra.Command{
+		Use:   "remove",
+		Short: "Remove components to an existing view",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := setContextStore(cmd); err != nil {
+				return err
+			}
+
+			if viewName == "" {
+				return fmt.Errorf("view name is required (use --name)")
+			}
+			return nil
+		},
+	}
+
+	cmd.PersistentFlags().StringVar(&viewName, "name", "", "Name of the view")
+
+	cmd.AddCommand(MakeRemoveQueryCommand(&viewName))
+	cmd.AddCommand(MakeRemoveSdlCommand(&viewName))
+	cmd.AddCommand(MakeRemoveLensCommand(&viewName))
+
+	return cmd
+}

--- a/cli/view_remove_lens.go
+++ b/cli/view_remove_lens.go
@@ -1,0 +1,36 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/shinzonetwork/view-creator/core/service"
+	"github.com/spf13/cobra"
+)
+
+func MakeRemoveLensCommand(viewName *string) *cobra.Command {
+	var label string
+
+	cmd := &cobra.Command{
+		Use:   "lens",
+		Short: "Remove a lens from the view",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if label == "" {
+				return fmt.Errorf("--label is required")
+			}
+
+			store := mustGetContextStore(cmd)
+
+			view, err := service.RemoveLens(*viewName, label, store)
+			if err != nil {
+				return err
+			}
+
+			printViewPretty(cmd, view, false, false)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&label, "label", "", "Label of the lens to remove")
+
+	return cmd
+}

--- a/cli/view_remove_lens_test.go
+++ b/cli/view_remove_lens_test.go
@@ -1,0 +1,89 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/shinzonetwork/view-creator/cli"
+	"github.com/shinzonetwork/view-creator/core/store/local"
+)
+
+func TestRemoveLensFromView(t *testing.T) {
+	tempDir := t.TempDir()
+
+	store, err := local.NewLocalStore(tempDir)
+	if err != nil {
+		t.Fatalf("failed to create temp store: %v", err)
+	}
+
+	viewName := "testview"
+
+	cmd := cli.MakeViewInitCommand()
+	cmd.SetArgs([]string{viewName})
+
+	var initBuf bytes.Buffer
+	cmd.SetOut(&initBuf)
+	cmd.SetErr(&initBuf)
+	cmd.SetContext(cli.WithStore(context.Background(), store))
+
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("view init command failed: %v", err)
+	}
+
+	wasmPath := filepath.Join(tempDir, "decode.wasm")
+	if err := os.WriteFile(wasmPath, []byte("\x00asm\x01\x00\x00\x00"), 0644); err != nil {
+		t.Fatalf("failed to write dummy wasm file: %v", err)
+	}
+
+	cmd = cli.MakeAddLensCommand(&viewName)
+
+	var addBuf bytes.Buffer
+	cmd.SetOut(&addBuf)
+	cmd.SetErr(&addBuf)
+	cmd.SetArgs([]string{
+		"--label", "decode_usdt",
+		"--path", wasmPath,
+		"--args", `{"token": "USDT"}`,
+	})
+	cmd.SetContext(cli.WithStore(context.Background(), store))
+
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("add lens command failed: %v", err)
+	}
+
+	cmd = cli.MakeRemoveLensCommand(&viewName)
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--label", "decode_usdt"})
+	cmd.SetContext(cli.WithStore(context.Background(), store))
+
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("remove lens command failed: %v", err)
+	}
+
+	out := buf.String()
+
+	expected := `📄 View: testview
+🔍 Query: <none>
+📐 SDL: <none>
+🔧 Lenses:
+ - (empty)
+
+🗂  Metadata:
+ - Version: 0
+ - Total: 0
+ - Created At: `
+
+	if !strings.HasPrefix(out, expected) {
+		t.Errorf("unexpected output after lens removal.\nGot:\n%s\nExpected prefix:\n%s", out, expected)
+	}
+}

--- a/cli/view_remove_query.go
+++ b/cli/view_remove_query.go
@@ -1,0 +1,24 @@
+package cli
+
+import (
+	"github.com/shinzonetwork/view-creator/core/service"
+	"github.com/spf13/cobra"
+)
+
+func MakeRemoveQueryCommand(viewName *string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "query",
+		Short: "Remove the query from the view",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store := mustGetContextStore(cmd)
+
+			view, err := service.ClearQuery(*viewName, store)
+			if err != nil {
+				return err
+			}
+
+			printViewPretty(cmd, view, false, false)
+			return nil
+		},
+	}
+}

--- a/cli/view_remove_query_test.go
+++ b/cli/view_remove_query_test.go
@@ -1,0 +1,78 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/shinzonetwork/view-creator/cli"
+	"github.com/shinzonetwork/view-creator/core/store/local"
+)
+
+func TestRemoveQueryFromView(t *testing.T) {
+	tempDir := t.TempDir()
+
+	store, err := local.NewLocalStore(tempDir)
+	if err != nil {
+		t.Fatalf("failed to create temp store: %v", err)
+	}
+
+	viewName := "testview"
+
+	cmd := cli.MakeViewInitCommand()
+	cmd.SetArgs([]string{viewName})
+
+	var initBuf bytes.Buffer
+	cmd.SetOut(&initBuf)
+	cmd.SetErr(&initBuf)
+	cmd.SetContext(cli.WithStore(context.Background(), store))
+
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("view init command failed: %v", err)
+	}
+
+	query := `Log { address topics }`
+	cmd = cli.MakeAddQueryCommand(&viewName)
+
+	var addBuf bytes.Buffer
+	cmd.SetOut(&addBuf)
+	cmd.SetErr(&addBuf)
+	cmd.SetArgs([]string{query})
+	cmd.SetContext(cli.WithStore(context.Background(), store))
+
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("add query command failed: %v", err)
+	}
+
+	cmd = cli.MakeRemoveQueryCommand(&viewName)
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetContext(cli.WithStore(context.Background(), store))
+
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("remove query command failed: %v", err)
+	}
+
+	out := buf.String()
+
+	expected := `📄 View: testview
+🔍 Query: <none>
+📐 SDL: <none>
+🔧 Lenses:
+ - (empty)
+
+🗂  Metadata:
+ - Version: 0
+ - Total: 0
+ - Created At: `
+
+	if !strings.HasPrefix(out, expected) {
+		t.Errorf("unexpected output after query removal.\nGot:\n%s\nExpected prefix:\n%s", out, expected)
+	}
+}

--- a/cli/view_remove_sdl.go
+++ b/cli/view_remove_sdl.go
@@ -1,0 +1,24 @@
+package cli
+
+import (
+	"github.com/shinzonetwork/view-creator/core/service"
+	"github.com/spf13/cobra"
+)
+
+func MakeRemoveSdlCommand(viewName *string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "sdl",
+		Short: "Remove the SDL from the view",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store := mustGetContextStore(cmd)
+
+			view, err := service.ClearSDL(*viewName, store)
+			if err != nil {
+				return err
+			}
+
+			printViewPretty(cmd, view, false, false)
+			return nil
+		},
+	}
+}

--- a/cli/view_remove_sdl_test.go
+++ b/cli/view_remove_sdl_test.go
@@ -1,0 +1,75 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/shinzonetwork/view-creator/cli"
+	"github.com/shinzonetwork/view-creator/core/store/local"
+)
+
+func TestRemoveSdlFromView(t *testing.T) {
+	tempDir := t.TempDir()
+
+	store, err := local.NewLocalStore(tempDir)
+	if err != nil {
+		t.Fatalf("failed to create temp store: %v", err)
+	}
+
+	viewName := "testview"
+
+	cmd := cli.MakeViewInitCommand()
+	cmd.SetArgs([]string{viewName})
+
+	var initBuf bytes.Buffer
+	cmd.SetOut(&initBuf)
+	cmd.SetErr(&initBuf)
+	cmd.SetContext(cli.WithStore(context.Background(), store))
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("view init command failed: %v", err)
+	}
+
+	sdl := `type ReturnedLog { address: string }`
+	cmd = cli.MakeAddSdlCommand(&viewName)
+
+	var addBuf bytes.Buffer
+	cmd.SetOut(&addBuf)
+	cmd.SetErr(&addBuf)
+	cmd.SetArgs([]string{sdl})
+	cmd.SetContext(cli.WithStore(context.Background(), store))
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("add SDL command failed: %v", err)
+	}
+
+	cmd = cli.MakeRemoveSdlCommand(&viewName)
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetContext(cli.WithStore(context.Background(), store))
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("remove SDL command failed: %v", err)
+	}
+
+	out := buf.String()
+
+	expected := `📄 View: testview
+🔍 Query: <none>
+📐 SDL: <none>
+🔧 Lenses:
+ - (empty)
+
+🗂  Metadata:
+ - Version: 0
+ - Total: 0
+ - Created At: `
+
+	if !strings.HasPrefix(out, expected) {
+		t.Errorf("unexpected output after SDL removal.\nGot:\n%s\nExpected prefix:\n%s", out, expected)
+	}
+}

--- a/cmd/viewkit/main.go
+++ b/cmd/viewkit/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"os"
+
+	"github.com/shinzonetwork/view-creator/cli"
+)
+
+func main() {
+	viewKitCli := cli.NewViewCreatorCommand()
+	if err := viewKitCli.Execute(); err != nil {
+		// this error is okay to discard because cobra
+		// logs any errors encountered during execution
+		//
+		// exiting with a non-zero status code signals
+		// that an error has ocurred during execution
+		os.Exit(1)
+	}
+}

--- a/core/service/init.go
+++ b/core/service/init.go
@@ -1,11 +1,17 @@
 package service
 
 import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/shinzonetwork/view-creator/core/models"
 	"github.com/shinzonetwork/view-creator/core/store"
+	"github.com/shinzonetwork/view-creator/core/util"
 )
 
 func InitView(name string, s store.ViewStore) (models.View, error) {
@@ -18,4 +24,96 @@ func InspectView(name string, s store.ViewStore) (models.View, error) {
 
 func DeleteView(name string, s store.ViewStore) error {
 	return s.Delete(name)
+}
+
+func UpdateQuery(name string, query string, s store.ViewStore) (models.View, error) {
+	view, err := s.Load(name)
+	if err != nil {
+		return models.View{}, err
+	}
+
+	// TODO: validate query
+
+	view.Query = &query
+
+	view, err = s.Save(name, view)
+	if err != nil {
+		return models.View{}, err
+	}
+
+	return view, nil
+}
+
+func UpdateSDL(name string, sdl string, s store.ViewStore) (models.View, error) {
+	view, err := s.Load(name)
+	if err != nil {
+		return models.View{}, err
+	}
+
+	// TODO: validate sdl
+
+	view.Sdl = &sdl
+
+	view, err = s.Save(name, view)
+	if err != nil {
+		return models.View{}, err
+	}
+
+	return view, nil
+}
+
+func InitLens(name string, label string, path string, args map[string]any, s store.ViewStore) (models.View, error) {
+	view, err := s.Load(name)
+	if err != nil {
+		return models.View{}, err
+	}
+
+	// Check if lens already exists
+	for _, lens := range view.Transform.Lenses {
+		if lens.Label == label {
+			return models.View{}, fmt.Errorf(`lens with label "%s" already exists`, label)
+		}
+	}
+
+	var file io.ReadCloser
+
+	// Check if it's a URL
+	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+		resp, err := http.Get(path)
+		if err != nil {
+			return models.View{}, fmt.Errorf("failed to download from URL: %w", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			return models.View{}, fmt.Errorf("download failed with HTTP %d", resp.StatusCode)
+		}
+		file = resp.Body
+	} else {
+		localFile, err := os.Open(path)
+		if err != nil {
+			return models.View{}, fmt.Errorf("failed to open local file: %w", err)
+		}
+		file = localFile
+	}
+	defer file.Close()
+
+	_, err = util.IsValidWasm(file)
+	if err != nil {
+		return models.View{}, fmt.Errorf("invalid wasm file: %w", err)
+	}
+
+	// Upload the asset
+	if _, err := s.UploadAsset(name, label, file); err != nil {
+		return models.View{}, fmt.Errorf("failed to upload asset: %w", err)
+	}
+
+	// Add the new lens with label and args
+	newLens := models.Lens{
+		Label:     label,
+		Arguments: args,
+		Path:      fmt.Sprintf("assets/%s.wasm", label),
+	}
+	view.Transform.Lenses = append(view.Transform.Lenses, newLens)
+
+	// Save the updated view
+	return s.Save(name, view)
 }

--- a/core/service/init.go
+++ b/core/service/init.go
@@ -1,0 +1,21 @@
+package service
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/shinzonetwork/view-creator/core/models"
+	"github.com/shinzonetwork/view-creator/core/store"
+)
+
+func InitView(name string, s store.ViewStore) (models.View, error) {
+	return s.Create(name, strconv.FormatInt(time.Now().Unix(), 10))
+}
+
+func InspectView(name string, s store.ViewStore) (models.View, error) {
+	return s.Load(name)
+}
+
+func DeleteView(name string, s store.ViewStore) error {
+	return s.Delete(name)
+}

--- a/core/store/interface.go
+++ b/core/store/interface.go
@@ -1,6 +1,10 @@
 package store
 
-import "github.com/shinzonetwork/view-creator/core/models"
+import (
+	"io"
+
+	"github.com/shinzonetwork/view-creator/core/models"
+)
 
 // ViewStore defines a contract for persisting and retrieving views across various storage.
 //
@@ -27,4 +31,10 @@ type ViewStore interface {
 	// Delete removes the view identified by name from the store.
 	// Returns the deleted View.
 	Delete(name string) error
+
+	// Uploads an asset (e.g. .wasm) to a view, identified by label.
+	UploadAsset(viewName string, label string, file io.Reader) (string, error)
+
+	// Deletes an asset by view name and label.
+	DeleteAsset(viewName string, label string) error
 }

--- a/core/store/interface.go
+++ b/core/store/interface.go
@@ -26,5 +26,5 @@ type ViewStore interface {
 
 	// Delete removes the view identified by name from the store.
 	// Returns the deleted View.
-	Delete(name string) (models.View, error)
+	Delete(name string) error
 }

--- a/core/store/local/local_store.go
+++ b/core/store/local/local_store.go
@@ -14,17 +14,18 @@ type LocalStore struct {
 	BasePath string
 }
 
-func NewLocalStore(path string) (*LocalStore, error) {
+func NewLocalStore(path ...string) (*LocalStore, error) {
 	var base string
 
-	if path == "" {
+	// check if a custom path was provided
+	if len(path) == 0 || path[0] == "" {
 		home, err := os.UserHomeDir()
 		if err != nil {
 			return nil, fmt.Errorf("unable to get home directory: %w", err)
 		}
 		base = filepath.Join(home, ".shinzo", "views")
 	} else {
-		base = filepath.Join(path, ".shinzo", "views")
+		base = filepath.Join(path[0], ".shinzo", "views")
 	}
 
 	if err := os.MkdirAll(base, 0755); err != nil {

--- a/core/store/local/local_store.go
+++ b/core/store/local/local_store.go
@@ -216,10 +216,13 @@ func (s *LocalStore) UploadAsset(name string, label string, file io.Reader) (str
 }
 
 func (s *LocalStore) DeleteAsset(viewName string, label string) error {
-	assetPath := filepath.Join(s.BasePath, ".shinzo", "views", viewName, "assets", fmt.Sprintf("%s.wasm", label))
+	folderBasePath := filepath.Join(s.BasePath, viewName)
+	assetFolderPath := filepath.Join(folderBasePath, "assets")
+	assetPath := filepath.Join(assetFolderPath, fmt.Sprintf("%s.wasm", label))
+
 	if err := os.Remove(assetPath); err != nil {
 		if os.IsNotExist(err) {
-			return nil
+			return nil // already deleted or never existed
 		}
 		return fmt.Errorf("failed to delete asset: %w", err)
 	}

--- a/core/util/wasm_helpers.go
+++ b/core/util/wasm_helpers.go
@@ -1,0 +1,23 @@
+package util
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+)
+
+func IsValidWasm(file io.Reader) (io.Reader, error) {
+	const wasmMagic = "\x00asm"
+
+	header := make([]byte, 4)
+	n, err := io.ReadFull(file, header)
+	if err != nil || n != 4 {
+		return nil, fmt.Errorf("unable to read wasm header: %w", err)
+	}
+
+	if string(header) != wasmMagic {
+		return nil, fmt.Errorf("file is not a valid wasm")
+	}
+
+	return io.MultiReader(bytes.NewReader(header), file), nil
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,9 @@
 module github.com/shinzonetwork/view-creator
 
 go 1.24.2
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/cobra v1.9.1 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
+github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
# Add CLI Support for View Mutation Actions

This MR introduces a complete CLI module for managing **Shinzo Views**, allowing users to create, inspect, modify, and delete views through the `viewkit` command-line tool.

##  What’s Included

- **Command Skeleton**: Adds `viewkit` root command with subcommands grouped under `view`
- **View Operations**:
  - `init` – initialize a new view
  - `inspect` – view details
  - `delete` – delete an existing view
- **Mutation Commands**:
  - `add` – add `query`, `sdl`, or `lens`
  - `remove` – remove `query`, `sdl`, or `lens`
- **Lens Management**:
  - Add lenses via local WASM path or remote URL
  - Store lens arguments in structured format
- **Testing**:
  - Comprehensive test suite for all CLI actions including edge cases and validation

##  Tests

- Full test coverage for:
  - Creating, updating, and deleting views
  - Adding/removing queries, SDL, and lenses
  - Asset upload and deletion
