### PR TITLE
added updates in vc

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,15 @@ Create, inspect, enrich, and deploy a view named **testdeploy**:
 - `view add lens` chainable WASM transforms that pre-process data
 - `wallet generate` create a local signing key (store securely)
 - `view deploy` publish the bundle to a target network
+
+---
+
+## Playground
+
+Start a local DefraDB node with the default schema and mock data for interactive exploration:
+
+```bash
+./viewkit playground
+```
+
+This launches DefraDB at `http://127.0.0.1:9181` where you can run GraphQL queries against the loaded schema. The node runs until you stop it with `Ctrl+C`.

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -12,6 +12,7 @@ func NewViewCreatorCommand() *cobra.Command {
 		view,
 		tool,
 		wallet,
+		MakePlaygroundCommand(),
 	)
 
 	return root

--- a/cli/playground.go
+++ b/cli/playground.go
@@ -1,0 +1,24 @@
+package cli
+
+import (
+	"github.com/shinzonetwork/shinzo-view-creator/core/schema/store/fileschema"
+	"github.com/shinzonetwork/shinzo-view-creator/core/service"
+	"github.com/spf13/cobra"
+)
+
+func MakePlaygroundCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "playground",
+		Short: "Start a local DefraDB node with schema and mock data",
+		Long:  "Starts DefraDB, applies the schema, inserts mock data, and keeps it running for exploration. No views are deployed.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			schemastore, err := fileschema.NewFileSchemaStore()
+			if err != nil {
+				return err
+			}
+			return service.StartLocalNodePlayground(schemastore, false)
+		},
+	}
+
+	return cmd
+}

--- a/cli/view.go
+++ b/cli/view.go
@@ -17,6 +17,7 @@ func MakeViewCommand() *cobra.Command {
 		},
 	}
 
+	cmd.AddCommand(MakeViewCreateCommand())
 	cmd.AddCommand(MakeViewInitCommand())
 	cmd.AddCommand(MakeViewRollbackCommand())
 	cmd.AddCommand(MakeViewDeleteCommand())

--- a/cli/view.go
+++ b/cli/view.go
@@ -25,6 +25,8 @@ func MakeViewCommand() *cobra.Command {
 	cmd.AddCommand(MakeViewRemoveCommand())
 	cmd.AddCommand(MakeViewDeployCommand())
 	cmd.AddCommand(MakeViewTestCommand())
+	cmd.AddCommand(MakeViewSizeCommand())
+	cmd.AddCommand(MakeViewListCommand())
 
 	return cmd
 }

--- a/cli/view_add_lens.go
+++ b/cli/view_add_lens.go
@@ -32,7 +32,7 @@ func MakeAddLensCommand(viewName *string) *cobra.Command {
 				return fmt.Errorf("--label is required")
 			}
 
-			var argsMap map[string]string
+			var argsMap map[string]any
 			if argsJson != "" {
 				if err := json.Unmarshal([]byte(argsJson), &argsMap); err != nil {
 					return fmt.Errorf("invalid --args JSON: %w", err)

--- a/cli/view_add_query_test.go
+++ b/cli/view_add_query_test.go
@@ -23,6 +23,9 @@ func TestAddQueryToExistingView(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create temp store: %v", err)
 	}
+	if err := schemastore.SaveCustom("type Log { address: String\n topics: [String]\n data: String\n transactionHash: String\n blockNumber: Int }"); err != nil {
+		t.Fatalf("failed to save custom schema: %v", err)
+	}
 
 	viewName := "testview"
 
@@ -86,6 +89,9 @@ func TestUpdateQueryOfExistingView(t *testing.T) {
 	schemastore, err := fileschema.NewFileSchemaStore(tempDir)
 	if err != nil {
 		t.Fatalf("failed to create temp store: %v", err)
+	}
+	if err := schemastore.SaveCustom("type Log { address: String\n topics: [String]\n data: String\n transactionHash: String\n blockNumber: Int }"); err != nil {
+		t.Fatalf("failed to save custom schema: %v", err)
 	}
 
 	viewName := "testview"

--- a/cli/view_create.go
+++ b/cli/view_create.go
@@ -1,0 +1,148 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/shinzonetwork/shinzo-view-creator/core/service"
+	"github.com/spf13/cobra"
+)
+
+func MakeViewCreateCommand() *cobra.Command {
+	var query string
+	var sdl string
+	var lenses []string
+	var verbose bool
+	var jsonOutput bool
+
+	cmd := &cobra.Command{
+		Use:   "create [name]",
+		Short: "Create a view with name, query, SDL, and lenses in one command",
+		Long: `Create a complete view in a single command.
+
+Lenses are specified with the --lens flag, which can be repeated.
+Each lens value uses the format: label:path (or label:url for remote WASM).
+To include arguments, use: label:path:{"key":"value"}
+
+Examples:
+  viewkit view create my-view \
+    --query '{ ethTransactions { hash from to value } }' \
+    --sdl 'type MyView { hash: String, from: String, to: String, value: String }' \
+    --lens 'filter:./filter.wasm:{"address":"0xA0b8..."}' \
+    --lens 'decode:./decode.wasm'
+`,
+		Args: cobra.ExactArgs(1),
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := setContextViewStore(cmd); err != nil {
+				return err
+			}
+			if err := setContextSchemaStore(cmd); err != nil {
+				return err
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			viewstore := mustGetContextViewStore(cmd)
+			schemastore := mustGetContextSchemaStore(cmd)
+
+			// Init the view
+			_, err := service.InitView(name, viewstore)
+			if err != nil {
+				return fmt.Errorf("failed to init view: %w", err)
+			}
+
+			// Cleanup on failure
+			cleanup := func(err error) error {
+				_ = service.DeleteView(name, viewstore)
+				return err
+			}
+
+			// Add query if provided
+			if query != "" {
+				if _, err := service.UpdateQuery(name, query, viewstore, schemastore); err != nil {
+					return cleanup(fmt.Errorf("failed to set query: %w", err))
+				}
+			}
+
+			// Add SDL if provided
+			if sdl != "" {
+				if _, err := service.UpdateSDL(name, sdl, viewstore); err != nil {
+					return cleanup(fmt.Errorf("failed to set SDL: %w", err))
+				}
+			}
+
+			// Add lenses if provided
+			for _, lensSpec := range lenses {
+				label, path, lensArgs, err := parseLensSpec(lensSpec)
+				if err != nil {
+					return cleanup(fmt.Errorf("invalid lens spec %q: %w", lensSpec, err))
+				}
+
+				if _, err := service.InitLens(name, label, path, lensArgs, viewstore); err != nil {
+					return cleanup(fmt.Errorf("failed to add lens %q: %w", label, err))
+				}
+			}
+
+			// Load final view and print
+			view, err := service.InspectView(name, viewstore)
+			if err != nil {
+				return cleanup(err)
+			}
+
+			printViewPretty(cmd, view, verbose, jsonOutput)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&query, "query", "", "GraphQL query for the view")
+	cmd.Flags().StringVar(&sdl, "sdl", "", "Schema definition for the view")
+	cmd.Flags().StringArrayVar(&lenses, "lens", nil, "Lens in format label:path or label:path:{\"args\":\"json\"} (repeatable)")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output the view in raw JSON format")
+	cmd.Flags().BoolVar(&verbose, "verbose", false, "Show full output including revision history")
+
+	return cmd
+}
+
+// parseLensSpec parses a lens specification string.
+// Format: label:path or label:path:{"args":"json"}
+func parseLensSpec(spec string) (label string, path string, args map[string]any, err error) {
+	// Find the first colon to get the label
+	firstColon := strings.Index(spec, ":")
+	if firstColon == -1 {
+		return "", "", nil, fmt.Errorf("expected format label:path or label:path:{args}")
+	}
+
+	label = spec[:firstColon]
+	rest := spec[firstColon+1:]
+
+	if label == "" {
+		return "", "", nil, fmt.Errorf("label cannot be empty")
+	}
+
+	// Find where JSON args start (look for :{)
+	jsonStart := strings.Index(rest, ":{")
+	if jsonStart == -1 {
+		// No args, rest is the path
+		path = rest
+		if path == "" {
+			return "", "", nil, fmt.Errorf("path cannot be empty")
+		}
+		return label, path, nil, nil
+	}
+
+	path = rest[:jsonStart]
+	argsStr := rest[jsonStart+1:]
+
+	if path == "" {
+		return "", "", nil, fmt.Errorf("path cannot be empty")
+	}
+
+	args = make(map[string]any)
+	if err := json.Unmarshal([]byte(argsStr), &args); err != nil {
+		return "", "", nil, fmt.Errorf("invalid args JSON: %w", err)
+	}
+
+	return label, path, args, nil
+}

--- a/cli/view_deploy.go
+++ b/cli/view_deploy.go
@@ -11,11 +11,12 @@ import (
 func MakeViewDeployCommand() *cobra.Command {
 	var target string
 	var rpc string
+	var url string
 	var debug bool
 
 	cmd := &cobra.Command{
 		Use:   "deploy <name>",
-		Short: "Deploy a view to local, devnet, or mainnet",
+		Short: "Deploy a view to local, playground, devnet, or mainnet",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			viewstore := mustGetContextViewStore(cmd)
@@ -34,6 +35,9 @@ func MakeViewDeployCommand() *cobra.Command {
 			case "local":
 				return service.StartLocalNodeAndDeployView(viewName, viewstore, schemastore, debug)
 
+			case "playground":
+				return service.DeployViewToPlayground(viewName, viewstore, schemastore, url)
+
 			case "devnet":
 				wallet, err := service.LoadWallet()
 				if err != nil {
@@ -45,13 +49,14 @@ func MakeViewDeployCommand() *cobra.Command {
 				return fmt.Errorf("target '%s' not yet supported", target)
 
 			default:
-				return fmt.Errorf("invalid target '%s'. Must be one of: local, devnet, mainnet", target)
+				return fmt.Errorf("invalid target '%s'. Must be one of: local, playground, devnet, mainnet", target)
 			}
 		},
 	}
 
-	cmd.Flags().StringVar(&target, "target", "", "Where to deploy the view: local, devnet, or mainnet (required)")
+	cmd.Flags().StringVar(&target, "target", "", "Where to deploy the view: local, playground, devnet, or mainnet (required)")
 	cmd.Flags().StringVar(&rpc, "rpc", "", "RPC endpoint URL (required for devnet/mainnet)")
+	cmd.Flags().StringVar(&url, "url", "http://127.0.0.1:9181", "DefraDB URL for playground target")
 	cmd.Flags().BoolVar(&debug, "debug", false, "Enable debug output")
 
 	cmd.MarkFlagRequired("target")

--- a/cli/view_list_command.go
+++ b/cli/view_list_command.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func MakeViewListCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List all local views",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			viewstore := mustGetContextViewStore(cmd)
+			views, err := viewstore.List()
+			if err != nil {
+				return err
+			}
+
+			if len(views) == 0 {
+				cmd.Println("No views found.")
+				return nil
+			}
+
+			home, _ := os.UserHomeDir()
+
+			type entry struct {
+				name    string
+				modTime time.Time
+			}
+			entries := make([]entry, 0, len(views))
+			for _, v := range views {
+				viewJSON := filepath.Join(home, ".shinzo", "views", v.Name, "view.json")
+				var modTime time.Time
+				if info, err := os.Stat(viewJSON); err == nil {
+					modTime = info.ModTime()
+				}
+				entries = append(entries, entry{v.Name, modTime})
+			}
+			sort.Slice(entries, func(i, j int) bool {
+				return entries[i].modTime.After(entries[j].modTime)
+			})
+			for _, e := range entries {
+				date := "-"
+				if !e.modTime.IsZero() {
+					date = e.modTime.Format(time.DateOnly)
+				}
+				cmd.Printf("📄 %-24s  %s\n", e.name, date)
+			}
+			return nil
+		},
+	}
+}

--- a/cli/view_remove_query_test.go
+++ b/cli/view_remove_query_test.go
@@ -23,6 +23,9 @@ func TestRemoveQueryFromView(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create temp store: %v", err)
 	}
+	if err := schemastore.SaveCustom("type Log { address: String\n topics: [String]\n data: String\n transactionHash: String\n blockNumber: Int }"); err != nil {
+		t.Fatalf("failed to save custom schema: %v", err)
+	}
 
 	viewName := "testview"
 

--- a/cli/view_rollback_test.go
+++ b/cli/view_rollback_test.go
@@ -23,6 +23,9 @@ func TestRollbackView(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create schema store: %v", err)
 	}
+	if err := schemaStore.SaveCustom("type Log { address: String\n topics: [String]\n data: String\n transactionHash: String\n blockNumber: Int }"); err != nil {
+		t.Fatalf("failed to save custom schema: %v", err)
+	}
 
 	viewName := "testrollback"
 

--- a/cli/view_size.go
+++ b/cli/view_size.go
@@ -1,0 +1,113 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/shinzonetwork/shinzo-view-creator/core/service"
+	"github.com/shinzonetwork/viewbundle-go"
+	"github.com/spf13/cobra"
+)
+
+func MakeViewSizeCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "size [name]",
+		Short: "Show the bundled wire size of a view",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			storeImpl := mustGetContextViewStore(cmd)
+			viewName := args[0]
+
+			view, err := storeImpl.Load(viewName)
+			if err != nil {
+				return err
+			}
+
+			if view.Query == nil || view.Sdl == nil {
+				return fmt.Errorf("view missing query or sdl")
+			}
+
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("unable to get home directory: %w", err)
+			}
+
+			assetsDir := filepath.Join(home, ".shinzo", "views", viewName, "assets")
+
+			vb := viewbundle.View{
+				Query: *view.Query,
+				Sdl:   *view.Sdl,
+				Transform: viewbundle.Transform{
+					Lenses: make([]viewbundle.Lens, 0, len(view.Transform.Lenses)),
+				},
+			}
+
+			fmt.Println()
+			for i, l := range view.Transform.Lenses {
+				wasmBase64, err := storeImpl.GetAssetBlob(viewName, l.Label)
+				if err != nil {
+					return fmt.Errorf("lens[%d] %q: %w", i, l.Label, err)
+				}
+
+				wasmPath := filepath.Join(assetsDir, l.Label+".wasm")
+				info, _ := os.Stat(wasmPath)
+				if info != nil {
+					fmt.Printf("  %-25s %s (raw) -> %s (base64)\n",
+						l.Label+".wasm",
+						formatSize(info.Size()),
+						formatSize(int64(len(wasmBase64))),
+					)
+				}
+
+				args := ""
+				switch v := any(l.Arguments).(type) {
+				case string:
+					args = v
+				default:
+					bz, _ := json.Marshal(l.Arguments)
+					args = string(bz)
+				}
+
+				vb.Transform.Lenses = append(vb.Transform.Lenses, viewbundle.Lens{
+					Path:      wasmBase64,
+					Arguments: args,
+				})
+			}
+
+			bd := viewbundle.NewBundler()
+			wireBytes, err := bd.BundleView(vb)
+			if err != nil {
+				return fmt.Errorf("failed to bundle: %w", err)
+			}
+
+			txData := service.EncodeRegisterBytesCalldata(wireBytes)
+
+			fmt.Println()
+			fmt.Printf("  %-25s %s\n", "Wire bundle", formatSize(int64(len(wireBytes))))
+			fmt.Printf("  %-25s %s\n", "Tx calldata", formatSize(int64(len(txData))))
+			fmt.Println()
+
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func formatSize(bytes int64) string {
+	const (
+		kb = 1024
+		mb = 1024 * kb
+	)
+
+	switch {
+	case bytes >= mb:
+		return fmt.Sprintf("%.2f MB", float64(bytes)/float64(mb))
+	case bytes >= kb:
+		return fmt.Sprintf("%.2f KB", float64(bytes)/float64(kb))
+	default:
+		return fmt.Sprintf("%d B", bytes)
+	}
+}

--- a/core/models/lens.go
+++ b/core/models/lens.go
@@ -3,5 +3,5 @@ package models
 type Lens struct {
 	Label     string            `json:"label"`
 	Path      string            `json:"path"`
-	Arguments map[string]string `json:"arguments"`
+	Arguments map[string]any `json:"arguments"`
 }

--- a/core/models/model_test.go
+++ b/core/models/model_test.go
@@ -15,7 +15,7 @@ func TestViewJSONMarshaling(t *testing.T) {
 	lensA := models.Lens{
 		Label: "filter_usdt",
 		Path:  "assets/lens_filter_usdt.wasm",
-		Arguments: map[string]string{
+		Arguments: map[string]any{
 			"src":   "address",
 			"value": "0xdac17f958d2ee523a2206206994597c13d831ec7",
 		},
@@ -24,7 +24,7 @@ func TestViewJSONMarshaling(t *testing.T) {
 	lensB := models.Lens{
 		Label: "decode_inputs",
 		Path:  "assets/lens_decode_inputs.wasm",
-		Arguments: map[string]string{
+		Arguments: map[string]any{
 			"abi": `{"inputs":[{"name":"_spender","type":"address"},{"name":"_value","type":"uint256"}]}`,
 		},
 	}

--- a/core/service/defra.go
+++ b/core/service/defra.go
@@ -11,7 +11,9 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"regexp"
 	"runtime"
+	"strings"
 	"syscall"
 	"time"
 
@@ -20,12 +22,166 @@ import (
 	viewstore "github.com/shinzonetwork/shinzo-view-creator/core/view/store"
 )
 
+const defraVersion = "1.0.0-rc1"
+const defraPort = "9181"
+
 var defraCmd *exec.Cmd
 
 type DefraViewPayload struct {
-	Query     string         `json:"Query"`
-	SDL       string         `json:"SDL"`
-	Transform map[string]any `json:"Transform"`
+	Query        string  `json:"Query"`
+	SDL          string  `json:"SDL"`
+	TransformCID *string `json:"TransformCID,omitempty"`
+}
+
+type DefraLensModule struct {
+	Path      string         `json:"Path"`
+	Arguments map[string]any `json:"Arguments,omitempty"`
+}
+
+type DefraLensInner struct {
+	Lenses []DefraLensModule `json:"Lenses"`
+}
+
+type DefraLensPayload struct {
+	Lens DefraLensInner `json:"Lens"`
+}
+
+func defraURL() string {
+	return "http://127.0.0.1:" + defraPort
+}
+
+func startDefraNode(debug bool) (string, error) {
+	bin, err := EnsureDefraBinary(defraVersion)
+	if err != nil {
+		return "", fmt.Errorf("failed to ensure defradb binary: %w", err)
+	}
+
+	rootDir, err := os.MkdirTemp("", "defradb-root-*")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp rootdir: %w", err)
+	}
+
+	env := append(os.Environ(), "DEFRA_KEYRING_SECRET=1234")
+
+	killExistingDefra()
+
+	defraCmd = exec.Command(bin, "start", "--rootdir", rootDir)
+	defraCmd.Env = env
+	defraCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	if debug {
+		defraCmd.Stdout = os.Stdout
+		defraCmd.Stderr = os.Stderr
+	}
+
+	if err := defraCmd.Start(); err != nil {
+		return "", fmt.Errorf("failed to start defradb: %w", err)
+	}
+
+	fmt.Println("🚀 DefraDB is running on port", defraPort)
+	fmt.Println("⏳ Waiting for DefraDB to boot up...")
+	time.Sleep(2 * time.Second)
+	fmt.Println("✅ DefraDB booted up")
+
+	return rootDir, nil
+}
+
+func registerLensAndCreateView(ctx context.Context, baseURL string, view models.View) (string, error) {
+	var transformCID *string
+
+	if len(view.Transform.Lenses) > 0 {
+		lensPayload, err := BuildLensPayload(view)
+		if err != nil {
+			return "", fmt.Errorf("failed to build lens payload: %w", err)
+		}
+
+		fmt.Println("📦 Registering lens transform...")
+		lensCID, err := RegisterLens(ctx, baseURL, lensPayload)
+		if err != nil {
+			return "", fmt.Errorf("failed to register lens: %w", err)
+		}
+		transformCID = &lensCID
+	}
+
+	viewPayload, err := BuildViewPayload(view, transformCID)
+	if err != nil {
+		return "", fmt.Errorf("failed to build view payload: %w", err)
+	}
+
+	return SendViewToDefra(ctx, baseURL, viewPayload)
+}
+
+func DeployViewToPlayground(name string, vs viewstore.ViewStore, ss schemastore.SchemaStore, url string) error {
+	ctx := context.Background()
+
+	fmt.Println("🔍 Loading view...")
+	view, err := vs.Load(name)
+	if err != nil {
+		return fmt.Errorf("❌ Failed to load view: %w", err)
+	}
+
+	fmt.Println("📦 Applying schema...")
+	schemaContent, err := ss.Load()
+	if err != nil {
+		return fmt.Errorf("❌ Failed to load schema: %w", err)
+	}
+	if err := ApplySchemaViaHTTP(ctx, url, schemaContent); err != nil {
+		return fmt.Errorf("❌ Failed to apply schema: %w", err)
+	}
+	fmt.Println("✅ Schema applied")
+
+	fmt.Println("🧠 Applying view...")
+	result, err := registerLensAndCreateView(ctx, url, view)
+	if err != nil {
+		return fmt.Errorf("❌ Failed to apply view: %w", err)
+	}
+	fmt.Println("✅ View applied")
+
+	collection, err := extractCollectionName(result)
+	if err != nil {
+		return fmt.Errorf("❌ Failed to extract collection name: %w", err)
+	}
+
+	fmt.Println("♻️  Refreshing view...")
+	if err := RefreshView(ctx, url, collection); err != nil {
+		return fmt.Errorf("❌ Failed to refresh view: %w", err)
+	}
+	fmt.Println("✅ View refreshed")
+
+	fmt.Println("🎉 View deployed to playground at", url+"/")
+	return nil
+}
+
+func StartLocalNodePlayground(schemastore schemastore.SchemaStore, debug bool) error {
+	ctx := context.Background()
+
+	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if _, err := startDefraNode(debug); err != nil {
+		return err
+	}
+
+	fmt.Println("⏳ Applying schema...")
+	schemaContent, err := schemastore.Load()
+	if err != nil {
+		return cleanupDefra("failed to load schema", err)
+	}
+
+	if err := ApplySchemaViaHTTP(ctx, defraURL(), schemaContent); err != nil {
+		return cleanupDefra("failed to apply schema", err)
+	}
+	fmt.Println("✅ Schema applied")
+
+	if err := InsertMockData(ctx, defraURL()); err != nil {
+		return cleanupDefra("failed to insert mock data", err)
+	}
+
+	fmt.Println("🧪 DefraDB playground ready at", defraURL()+"/")
+	fmt.Println("📦 Press Ctrl+C to stop...")
+
+	<-ctx.Done()
+	return shutdownDefra()
 }
 
 func StartLocalNodeAndDeployView(name string, viewstore viewstore.ViewStore, schemastore schemastore.SchemaStore, debug bool) error {
@@ -36,46 +192,12 @@ func StartLocalNodeAndDeployView(name string, viewstore viewstore.ViewStore, sch
 		return err
 	}
 
-	viewJson, err := ConvertViewToDefraJson(view)
-	if err != nil {
-		return err
-	}
-
 	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	port := "9181"
-
-	bin, err := EnsureDefraBinary("0.18.0")
-	if err != nil {
-		return fmt.Errorf("failed to ensure defradb binary: %w", err)
+	if _, err := startDefraNode(debug); err != nil {
+		return err
 	}
-
-	rootDir, err := os.MkdirTemp("", "defradb-root-*")
-	if err != nil {
-		return fmt.Errorf("failed to create temp rootdir: %w", err)
-	}
-
-	env := append(os.Environ(),
-		"DEFRA_KEYRING_SECRET=1234",
-	)
-
-	defraCmd = exec.Command(bin, "start", "--rootdir", rootDir)
-	defraCmd.Env = env
-
-	if debug {
-		defraCmd.Stdout = os.Stdout
-		defraCmd.Stderr = os.Stderr
-	}
-
-	if err := defraCmd.Start(); err != nil {
-		return fmt.Errorf("failed to start defradb: %w", err)
-	}
-
-	fmt.Println("🚀 DefraDB is running on port", port)
-	fmt.Println("⏳ Waiting for DefraDB to boot up...")
-	time.Sleep(2 * time.Second)
-	fmt.Println("✅ DefraDB booted up")
 
 	fmt.Println("⏳ Applying Schemas ...")
 	schemaContent, err := schemastore.Load()
@@ -83,21 +205,18 @@ func StartLocalNodeAndDeployView(name string, viewstore viewstore.ViewStore, sch
 		return cleanupDefra("failed to load schema", err)
 	}
 
-	schemaCmd := exec.Command(bin, "client", "schema", "add", schemaContent, "--rootdir", rootDir)
-	schemaCmd.Env = env
-
-	if err := schemaCmd.Run(); err != nil {
+	if err := ApplySchemaViaHTTP(ctx, defraURL(), schemaContent); err != nil {
 		return cleanupDefra("failed to apply schema", err)
 	}
 	fmt.Println("✅ Schema Applied")
 
-	if err := InsertDataToDefra(ctx, GQL); err != nil {
+	if err := InsertMockData(ctx, defraURL()); err != nil {
 		return cleanupDefra("failed to insert data", err)
 	}
 
 	fmt.Println("✅ Applying View ...")
 
-	result, err := SendViewToDefra(ctx, "http://127.0.0.1:9181", viewJson)
+	result, err := registerLensAndCreateView(ctx, defraURL(), view)
 	if err != nil {
 		return cleanupDefra("failed to send view", err)
 	}
@@ -107,14 +226,14 @@ func StartLocalNodeAndDeployView(name string, viewstore viewstore.ViewStore, sch
 		return cleanupDefra("failed to send view", err)
 	}
 
-	err = RefreshView(ctx, "http://127.0.0.1:9181", collection)
+	err = RefreshView(ctx, defraURL(), collection)
 	if err != nil {
 		return cleanupDefra("failed to send view", err)
 	}
 
 	fmt.Println("✅ View Successfully Applied")
 
-	fmt.Println("🧪 Visit the DefraDB GraphQL Playground at http://127.0.0.1:9181/")
+	fmt.Println("🧪 Visit the DefraDB GraphQL Playground at", defraURL()+"/")
 	fmt.Println("📦 Press Ctrl+C to stop...")
 
 	<-ctx.Done()
@@ -124,51 +243,18 @@ func StartLocalNodeAndDeployView(name string, viewstore viewstore.ViewStore, sch
 func StartLocalNodeAndTestView(name string, viewstore viewstore.ViewStore, schemastore schemastore.SchemaStore, debug bool) error {
 	ctx := context.Background()
 
+	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	fmt.Println("🔍 Loading view...")
 	view, err := viewstore.Load(name)
 	if err != nil {
 		return fmt.Errorf("❌ Failed to load view: %w", err)
 	}
 
-	viewJson, err := ConvertViewToDefraJson(view)
-	if err != nil {
-		return fmt.Errorf("❌ Failed to convert view to JSON: %w", err)
+	if _, err := startDefraNode(debug); err != nil {
+		return err
 	}
-
-	fmt.Println("⚙️  Ensuring DefraDB binary...")
-	bin, err := EnsureDefraBinary("0.18.0")
-	if err != nil {
-		return fmt.Errorf("❌ Failed to ensure DefraDB binary: %w", err)
-	}
-
-	fmt.Println("📁 Creating temporary root directory...")
-	rootDir, err := os.MkdirTemp("", "defradb-root-*")
-	if err != nil {
-		return fmt.Errorf("❌ Failed to create temp rootdir: %w", err)
-	}
-
-	env := append(os.Environ(),
-		"DEFRA_KEYRING_SECRET=1234",
-	)
-
-	fmt.Println("🚀 Starting DefraDB...")
-	defraCmd = exec.Command(bin, "start", "--rootdir", rootDir)
-
-	// This is here for debug purposes; Show command output as it happens
-	if debug {
-		defraCmd.Stdout = os.Stdout
-		defraCmd.Stderr = os.Stderr
-	}
-
-	defraCmd.Env = env
-
-	if err := defraCmd.Start(); err != nil {
-		return fmt.Errorf("❌ Failed to start DefraDB: %w", err)
-	}
-
-	fmt.Println("⏳ Waiting for DefraDB to boot...")
-	time.Sleep(2 * time.Second)
-	fmt.Println("✅ DefraDB booted")
 
 	fmt.Println("📦 Applying schema...")
 	schemaContent, err := schemastore.Load()
@@ -176,26 +262,19 @@ func StartLocalNodeAndTestView(name string, viewstore viewstore.ViewStore, schem
 		return cleanupDefra("❌ Failed to load schema", err)
 	}
 
-	schemaCmd := exec.Command(bin, "client", "schema", "add", schemaContent, "--rootdir", rootDir)
-	schemaCmd.Env = env
-
-	// This is here for debug purposes; Show command output as it happens
-	// schemaCmd.Stdout = os.Stdout
-	// schemaCmd.Stderr = os.Stderr
-
-	if err := schemaCmd.Run(); err != nil {
+	if err := ApplySchemaViaHTTP(ctx, defraURL(), schemaContent); err != nil {
 		return cleanupDefra("❌ Failed to apply schema", err)
 	}
 	fmt.Println("✅ Schema applied")
 
 	fmt.Println("📨 Inserting test data...")
-	if err := InsertDataToDefra(ctx, GQL); err != nil {
+	if err := InsertMockData(ctx, defraURL()); err != nil {
 		return cleanupDefra("❌ Failed to insert data", err)
 	}
 	fmt.Println("✅ Data inserted")
 
 	fmt.Println("🧠 Applying view...")
-	result, err := SendViewToDefra(ctx, "http://127.0.0.1:9181", viewJson)
+	result, err := registerLensAndCreateView(ctx, defraURL(), view)
 	if err != nil {
 		return cleanupDefra("❌ Failed to apply view", err)
 	}
@@ -208,45 +287,124 @@ func StartLocalNodeAndTestView(name string, viewstore viewstore.ViewStore, schem
 	}
 
 	fmt.Println("♻️  Refreshing view...")
-	err = RefreshView(ctx, "http://127.0.0.1:9181", collection)
+	err = RefreshView(ctx, defraURL(), collection)
 	if err != nil {
 		return cleanupDefra("❌ Failed to refresh view", err)
 	}
 	fmt.Println("✅ View refreshed")
 
+	fmt.Println("🔎 Querying view results...")
+	fields := extractSDLFields(deref(view.Sdl))
+	query := fmt.Sprintf(`{ %s { %s } }`, collection, strings.Join(fields, " "))
+	queryResult, err := QueryDefra(ctx, defraURL(), query)
+	if err != nil {
+		return cleanupDefra("❌ Failed to query view", err)
+	}
+	fmt.Println("📊 View results:")
+	fmt.Println(queryResult)
+
 	fmt.Println("✅ Test flow completed successfully. Shutting down...")
 	return shutdownDefra()
 }
 
-func ConvertViewToDefraJson(view models.View) (string, error) {
-	transform := map[string]any{
-		"lenses": []map[string]any{},
-	}
-
-	for _, lens := range view.Transform.Lenses {
-		lensMap := map[string]any{
-			"path":      getPathInViewAssets(view.Name, lens.Path),
-			"arguments": lens.Arguments,
-		}
-		transform["lenses"] = append(transform["lenses"].([]map[string]any), lensMap)
-	}
-
+func BuildViewPayload(view models.View, transformCID *string) (string, error) {
 	payload := DefraViewPayload{
-		Query:     deref(view.Query),
-		SDL:       deref(view.Sdl),
-		Transform: transform,
+		Query:        deref(view.Query),
+		SDL:          deref(view.Sdl),
+		TransformCID: transformCID,
 	}
 
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(payload); err != nil {
 		return "", err
 	}
-
 	return buf.String(), nil
 }
 
-func SendViewToDefra(ctx context.Context, defraURL string, jsonPayload string) (string, error) {
-	url := defraURL + "/api/v0/view"
+func BuildLensPayload(view models.View) (string, error) {
+	modules := make([]DefraLensModule, 0, len(view.Transform.Lenses))
+	for _, lens := range view.Transform.Lenses {
+		wasmBase64 := getPathInViewAssets(view.Name, lens.Path)
+		args := make(map[string]any, len(lens.Arguments))
+		for k, v := range lens.Arguments {
+			args[k] = v
+		}
+		modules = append(modules, DefraLensModule{
+			Path:      wasmBase64,
+			Arguments: args,
+		})
+	}
+
+	payload := DefraLensPayload{Lens: DefraLensInner{Lenses: modules}}
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(payload); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+func RegisterLens(ctx context.Context, baseURL string, lensPayload string) (string, error) {
+	url := baseURL + "/api/v0/lens"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBufferString(lensPayload))
+	if err != nil {
+		return "", fmt.Errorf("failed to create lens request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to send lens request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return "", fmt.Errorf("lens registration failed (%d): %s", resp.StatusCode, string(body))
+	}
+
+	var lensResp struct {
+		LensID string `json:"lensId"`
+	}
+	if err := json.Unmarshal(body, &lensResp); err != nil {
+		return "", fmt.Errorf("failed to parse lens response: %w", err)
+	}
+	if lensResp.LensID == "" {
+		return "", fmt.Errorf("no lensId in response: %s", string(body))
+	}
+
+	return lensResp.LensID, nil
+}
+
+func ApplySchemaViaHTTP(ctx context.Context, baseURL string, schema string) error {
+	url := baseURL + "/api/v0/collections"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBufferString(schema))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		if resp.StatusCode == http.StatusBadRequest && strings.Contains(string(body), "collection already exists") {
+			return nil
+		}
+		return fmt.Errorf("unexpected status code %d: %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+func SendViewToDefra(ctx context.Context, baseURL string, jsonPayload string) (string, error) {
+	url := baseURL + "/api/v0/view"
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBufferString(jsonPayload))
 	if err != nil {
@@ -265,14 +423,22 @@ func SendViewToDefra(ctx context.Context, defraURL string, jsonPayload string) (
 	body, _ := io.ReadAll(resp.Body)
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		if resp.StatusCode == http.StatusBadRequest {
+			bodyStr := string(body)
+			if idx := strings.Index(bodyStr, "collection already exists. Name: "); idx >= 0 {
+				name := strings.TrimSpace(bodyStr[idx+len("collection already exists. Name: "):])
+				name = strings.FieldsFunc(name, func(r rune) bool { return r == '"' || r == '}' || r == '\n' })[0]
+				return fmt.Sprintf(`[{"Name":%q}]`, name), nil
+			}
+		}
 		return "", fmt.Errorf("unexpected status code %d: %s", resp.StatusCode, string(body))
 	}
 
 	return string(body), nil
 }
 
-func RefreshView(ctx context.Context, defraURL string, collection string) error {
-	url := fmt.Sprintf("%s/api/v0/view/refresh?name=%s", defraURL, collection)
+func RefreshView(ctx context.Context, baseURL string, collection string) error {
+	url := fmt.Sprintf("%s/api/v0/view/refresh?name=%s", baseURL, collection)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
 	if err != nil {
@@ -294,29 +460,6 @@ func RefreshView(ctx context.Context, defraURL string, collection string) error 
 	return nil
 }
 
-// func extractCollectionName(result string) (string, error) {
-// 	var parsed []map[string]interface{}
-// 	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
-// 		return "", fmt.Errorf("failed to parse result: %w", err)
-// 	}
-
-// 	if len(parsed) == 0 {
-// 		return "", fmt.Errorf("empty result")
-// 	}
-
-// 	version, ok := parsed[0]["version"].(map[string]interface{})
-// 	if !ok {
-// 		return "", fmt.Errorf("missing or invalid 'version' field")
-// 	}
-
-// 	name, ok := version["Name"].(string)
-// 	if !ok {
-// 		return "", fmt.Errorf("missing or invalid 'Name' field")
-// 	}
-
-// 	return name, nil
-// }
-
 func extractCollectionName(result string) (string, error) {
 	var parsed []map[string]any
 	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
@@ -326,7 +469,6 @@ func extractCollectionName(result string) (string, error) {
 		return "", fmt.Errorf("empty result")
 	}
 
-	// Format A: { "version": { "Name": ... }, "schema": ... }
 	if vRaw, ok := parsed[0]["version"]; ok && vRaw != nil {
 		if v, ok := vRaw.(map[string]any); ok {
 			if name, ok := v["Name"].(string); ok && name != "" {
@@ -337,7 +479,6 @@ func extractCollectionName(result string) (string, error) {
 		return "", fmt.Errorf("invalid 'version' type")
 	}
 
-	// Format B: { "Name": "...", "VersionID": "...", ... }
 	if name, ok := parsed[0]["Name"].(string); ok && name != "" {
 		return name, nil
 	}
@@ -345,7 +486,67 @@ func extractCollectionName(result string) (string, error) {
 	return "", fmt.Errorf("missing 'Name' in both formats")
 }
 
-func InsertDataToDefra(ctx context.Context, data string) error {
+func InsertMockData(ctx context.Context, baseURL string) error {
+	fmt.Println("⏳ Inserting mock data (phase 1: blocks)...")
+	if err := InsertDataToDefra(ctx, baseURL, GQL_BLOCKS); err != nil {
+		return fmt.Errorf("failed to insert blocks: %w", err)
+	}
+
+	fmt.Println("⏳ Inserting mock data (phase 2: transactions)...")
+	if err := InsertDataToDefra(ctx, baseURL, GQL_TRANSACTIONS); err != nil {
+		return fmt.Errorf("failed to insert transactions: %w", err)
+	}
+
+	fmt.Println("⏳ Querying docIDs for relation linking...")
+	blockDocIDs, err := queryDocIDsByHash(ctx, baseURL, "Ethereum__Mainnet__Block")
+	if err != nil {
+		return fmt.Errorf("failed to query block docIDs: %w", err)
+	}
+	txDocIDs, err := queryDocIDsByHash(ctx, baseURL, "Ethereum__Mainnet__Transaction")
+	if err != nil {
+		return fmt.Errorf("failed to query transaction docIDs: %w", err)
+	}
+	fmt.Printf("   blocks: %d, transactions: %d\n", len(blockDocIDs), len(txDocIDs))
+
+	fmt.Println("⏳ Inserting mock data (phase 3: logs with relations)...")
+	logsMutation := BuildLogsMutation(blockDocIDs, txDocIDs)
+	if err := InsertDataToDefra(ctx, baseURL, logsMutation); err != nil {
+		return fmt.Errorf("failed to insert logs: %w", err)
+	}
+
+	fmt.Println("✅ Mock data inserted")
+	return nil
+}
+
+func queryDocIDsByHash(ctx context.Context, baseURL, typeName string) (map[string]string, error) {
+	query := fmt.Sprintf(`{ %s { hash _docID } }`, typeName)
+	result, err := QueryDefra(ctx, baseURL, query)
+	if err != nil {
+		return nil, err
+	}
+
+	var parsed struct {
+		Data map[string][]struct {
+			Hash  string `json:"hash"`
+			DocID string `json:"_docID"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+		return nil, fmt.Errorf("failed to parse query response: %w", err)
+	}
+
+	docIDs := make(map[string]string)
+	for _, docs := range parsed.Data {
+		for _, v := range docs {
+			if v.Hash != "" && v.DocID != "" {
+				docIDs[v.Hash] = v.DocID
+			}
+		}
+	}
+	return docIDs, nil
+}
+
+func InsertDataToDefra(ctx context.Context, baseURL string, data string) error {
 	fmt.Println("⏳ Data Inserting...")
 
 	reqBody := map[string]string{
@@ -357,7 +558,7 @@ func InsertDataToDefra(ctx context.Context, data string) error {
 		return fmt.Errorf("failed to encode request body: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", "http://127.0.0.1:9181/api/v0/graphql", buf)
+	req, err := http.NewRequestWithContext(ctx, "POST", baseURL+"/api/v0/graphql", buf)
 	if err != nil {
 		return fmt.Errorf("failed to create HTTP request: %w", err)
 	}
@@ -372,6 +573,10 @@ func InsertDataToDefra(ctx context.Context, data string) error {
 	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+
+	if bodyStr := string(body); strings.Contains(bodyStr, `"errors"`) {
+		fmt.Println("⚠️  Insert response has errors:", bodyStr[:min(len(bodyStr), 500)])
 	}
 
 	fmt.Println("✅ Data Inserted Successfully")
@@ -430,10 +635,9 @@ func DownloadDefraDB(version string, dir ...string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-	    body, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
-	    return fmt.Errorf("failed to download defradb (%s): status %d: %s", url, resp.StatusCode, string(body))
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
+		return fmt.Errorf("failed to download defradb (%s): status %d: %s", url, resp.StatusCode, string(body))
 	}
-
 
 	binary := filepath.Join(base, "defradb")
 	out, err := os.Create(binary)
@@ -477,16 +681,48 @@ func DeleteDefraDB(dir ...string) error {
 }
 
 func shutdownDefra() error {
-	if defraCmd != nil && defraCmd.Process != nil {
-		if err := defraCmd.Process.Signal(syscall.SIGTERM); err != nil {
-			fmt.Println("⚠️ Could not send SIGTERM:", err)
-		} else if err := defraCmd.Wait(); err != nil {
+	if defraCmd == nil || defraCmd.Process == nil {
+		return nil
+	}
+
+	pid := defraCmd.Process.Pid
+	pgid := -pid
+
+	if err := syscall.Kill(pgid, syscall.SIGTERM); err != nil {
+		fmt.Println("⚠️ Could not send SIGTERM to process group:", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- defraCmd.Wait() }()
+
+	select {
+	case err := <-done:
+		if err != nil {
 			fmt.Println("⚠️ DefraDB did not exit cleanly:", err)
 		} else {
 			fmt.Println("✅ DefraDB stopped.")
 		}
+	case <-time.After(5 * time.Second):
+		fmt.Println("⚠️ DefraDB did not stop in time, force killing...")
+		_ = syscall.Kill(pgid, syscall.SIGKILL)
+		<-done
+		fmt.Println("✅ DefraDB force killed.")
 	}
+
+	defraCmd = nil
 	return nil
+}
+
+func killExistingDefra() {
+	out, err := exec.Command("lsof", "-ti", "tcp:"+defraPort).Output()
+	if err != nil || len(out) == 0 {
+		return
+	}
+	for _, pidStr := range bytes.Split(bytes.TrimSpace(out), []byte("\n")) {
+		fmt.Printf("⚠️ Killing leftover defradb process (pid %s) on port %s\n", pidStr, defraPort)
+		_ = exec.Command("kill", "-9", string(pidStr)).Run()
+	}
+	time.Sleep(500 * time.Millisecond)
 }
 
 func cleanupDefra(reason string, err error) error {
@@ -496,20 +732,41 @@ func cleanupDefra(reason string, err error) error {
 }
 
 func defraDownloadURL(version string) string {
-    osName := runtime.GOOS
-    arch := runtime.GOARCH
+	osName := runtime.GOOS
+	arch := runtime.GOARCH
 
-    // DefraDB v0.18.0 release assets use x86_64 (not amd64) for Linux/Windows filenames.
-    if arch == "amd64" {
-        arch = "x86_64"
-    }
+	if arch == "amd64" {
+		arch = "x86_64"
+	}
 
-    return fmt.Sprintf(
-        "https://github.com/sourcenetwork/defradb/releases/download/v%s/defradb_%s_%s_%s",
-        version, version, osName, arch,
-    )
+	return fmt.Sprintf(
+		"https://github.com/sourcenetwork/defradb/releases/download/v%s/defradb_%s_%s_%s",
+		version, version, osName, arch,
+	)
 }
 
+func QueryDefra(ctx context.Context, baseURL string, query string) (string, error) {
+	reqBody := map[string]string{"query": query}
+	buf := new(bytes.Buffer)
+	if err := json.NewEncoder(buf).Encode(reqBody); err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", baseURL+"/api/v0/graphql", buf)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	return string(body), nil
+}
 
 func getPathInViewAssets(viewName, relativePath string) string {
 	home, err := os.UserHomeDir()
@@ -525,4 +782,19 @@ func deref(s *string) string {
 		return ""
 	}
 	return *s
+}
+
+func extractSDLFields(sdl string) []string {
+	braceIdx := strings.Index(sdl, "{")
+	if braceIdx < 0 {
+		return nil
+	}
+	body := sdl[braceIdx:]
+	re := regexp.MustCompile(`(\w+)\s*:\s*(?:String|Int|Float|Boolean|ID|\[)`)
+	matches := re.FindAllStringSubmatch(body, -1)
+	var fields []string
+	for _, m := range matches {
+		fields = append(fields, m[1])
+	}
+	return fields
 }

--- a/core/service/deploy.go
+++ b/core/service/deploy.go
@@ -102,6 +102,12 @@ func StartLocalNodeTestAndDeploy(
 			return fmt.Errorf("lens[%d] missing Path (expected base64 wasm)", i)
 		}
 
+		// Read the wasm file and base64-encode it for the bundler
+		wasmBase64, err := viewstore.GetAssetBlob(name, l.Label)
+		if err != nil {
+			return fmt.Errorf("lens[%d] failed to load wasm blob: %w", i, err)
+		}
+
 		// If it's a map/struct, marshal to JSON string.
 		args := ""
 		switch v := any(l.Arguments).(type) {
@@ -116,7 +122,7 @@ func StartLocalNodeTestAndDeploy(
 		}
 
 		vb.Transform.Lenses = append(vb.Transform.Lenses, viewbundle.Lens{
-			Path:      l.Path,
+			Path:      wasmBase64,
 			Arguments: args,
 		})
 	}
@@ -233,7 +239,7 @@ func sendRegisterTx(
 	}
 
 	// Encode register(bytes) calldata
-	input := encodeRegisterBytesCalldata(payload)
+	input := EncodeRegisterBytesCalldata(payload)
 
 	to := common.HexToAddress(contractAddr)
 
@@ -266,7 +272,7 @@ func sendRegisterTx(
 	return signedTx.Hash().Hex(), nil
 }
 
-func encodeRegisterBytesCalldata(payload []byte) []byte {
+func EncodeRegisterBytesCalldata(payload []byte) []byte {
 	// methodID = keccak256("register(bytes)")[:4]
 	methodID := crypto.Keccak256([]byte("register(bytes)"))[:4]
 

--- a/core/service/deploy.go
+++ b/core/service/deploy.go
@@ -33,6 +33,12 @@ type ViewLite struct {
 	Transform models.Transform `json:"transform"`
 }
 
+type txResult struct {
+	TxHash      string
+	GasUsed     uint64
+	BlockNumber uint64
+}
+
 // ---------------------------
 // Deploy entry
 // ---------------------------
@@ -163,7 +169,7 @@ func StartLocalNodeTestAndDeploy(
 		return err
 	}
 
-	txHash, err := sendRegisterTx(rpc, SHINZO_HUB_PRECOMPILED_VIEW_REGISTRY_ADDRESS, privateKey, wireBytes)
+	result, err := sendRegisterTx(rpc, SHINZO_HUB_PRECOMPILED_VIEW_REGISTRY_ADDRESS, privateKey, wireBytes)
 	if err != nil {
 		return err
 	}
@@ -172,8 +178,10 @@ func StartLocalNodeTestAndDeploy(
 	fmt.Println("----------------------------------------")
 	fmt.Printf("🔑 View ID:           %s\n", viewID)
 	fmt.Printf("🔑 View Key:          %s\n", viewHash.Hex())
-	fmt.Printf("📦 Transaction Hash:  %s\n", txHash)
-	fmt.Printf("Wire bytes (tx data):%d\n", len(wireBytes))
+	fmt.Printf("📦 Transaction Hash:  %s\n", result.TxHash)
+	fmt.Printf("⛽ Gas Used:          %d\n", result.GasUsed)
+	fmt.Printf("🧱 Block Number:      %d\n", result.BlockNumber)
+	fmt.Printf("📏 Wire bytes (size): %d\n", len(wireBytes))
 	fmt.Println("----------------------------------------")
 
 	return nil
@@ -211,10 +219,10 @@ func sendRegisterTx(
 	contractAddr string,
 	privateKey *ecdsa.PrivateKey,
 	payload []byte,
-) (string, error) {
+) (txResult, error) {
 	client, err := ethclient.Dial(rpcURL)
 	if err != nil {
-		return "", fmt.Errorf("failed to connect to RPC: %w", err)
+		return txResult{}, fmt.Errorf("failed to connect to RPC: %w", err)
 	}
 	defer client.Close()
 
@@ -225,17 +233,17 @@ func sendRegisterTx(
 
 	nonce, err := client.PendingNonceAt(ctx, fromAddress)
 	if err != nil {
-		return "", fmt.Errorf("failed to get nonce: %w", err)
+		return txResult{}, fmt.Errorf("failed to get nonce: %w", err)
 	}
 
 	gasPrice, err := client.SuggestGasPrice(ctx)
 	if err != nil {
-		return "", fmt.Errorf("failed to get gas price: %w", err)
+		return txResult{}, fmt.Errorf("failed to get gas price: %w", err)
 	}
 
 	chainID, err := client.NetworkID(ctx)
 	if err != nil {
-		return "", fmt.Errorf("failed to get chain ID: %w", err)
+		return txResult{}, fmt.Errorf("failed to get chain ID: %w", err)
 	}
 
 	// Encode register(bytes) calldata
@@ -262,14 +270,43 @@ func sendRegisterTx(
 
 	signedTx, err := types.SignTx(tx, types.NewEIP155Signer(chainID), privateKey)
 	if err != nil {
-		return "", fmt.Errorf("failed to sign tx: %w", err)
+		return txResult{}, fmt.Errorf("failed to sign tx: %w", err)
 	}
 
 	if err := client.SendTransaction(ctx, signedTx); err != nil {
-		return "", fmt.Errorf("failed to send tx: %w", err)
+		return txResult{}, fmt.Errorf("failed to send tx: %w", err)
 	}
 
-	return signedTx.Hash().Hex(), nil
+	txHash := signedTx.Hash()
+	fmt.Printf("⏳ Transaction sent (%s). Waiting for confirmation...\n", txHash.Hex())
+
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return txResult{}, fmt.Errorf("timed out waiting for tx receipt (tx may still succeed): %s", txHash.Hex())
+		case <-ticker.C:
+			receipt, err := client.TransactionReceipt(ctx, txHash)
+			if err != nil {
+				continue
+			}
+
+			if receipt.Status == types.ReceiptStatusFailed {
+				return txResult{}, fmt.Errorf(
+					"❌ transaction reverted on-chain (gas used: %d, tx: %s)",
+					receipt.GasUsed, txHash.Hex(),
+				)
+			}
+
+			return txResult{
+				TxHash:      txHash.Hex(),
+				GasUsed:     receipt.GasUsed,
+				BlockNumber: receipt.BlockNumber.Uint64(),
+			}, nil
+		}
+	}
 }
 
 func EncodeRegisterBytesCalldata(payload []byte) []byte {

--- a/core/service/deploy_revert_test.go
+++ b/core/service/deploy_revert_test.go
@@ -1,0 +1,63 @@
+package service
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+// TestSendRegisterTx_RevertsOnInvalidPayload verifies that sendRegisterTx
+// returns an error when the on-chain transaction reverts.
+//
+// This is an integration test that requires a running local ShinzoHub node.
+// It sends garbage bytes (not valid VWL format) to the ViewRegistry
+// precompile, which causes viewbundle.DecodeHeader() to fail and the
+// precompile to revert. The test confirms that sendRegisterTx detects
+// the revert via receipt status instead of silently reporting success.
+//
+// Prerequisites:
+//   - Local ShinzoHub testnet: cd shinzohub && make sh-testnet
+//   - Export key: export TEST_PRIVATE_KEY=$(./build/shinzohubd keys unsafe-export-eth-key acc0 --keyring-backend test --home ~/.shinzohub)
+//
+// Run:
+//
+//	TEST_PRIVATE_KEY=<hex> go test ./core/service/ -run TestSendRegisterTx_RevertsOnInvalidPayload -v -count=1
+func TestSendRegisterTx_RevertsOnInvalidPayload(t *testing.T) {
+	rpcURL := "http://localhost:8545"
+
+	client, err := ethclient.Dial(rpcURL)
+	if err != nil {
+		t.Skip("skipping: local chain not reachable at", rpcURL)
+	}
+	client.Close()
+
+	acc0Key := os.Getenv("TEST_PRIVATE_KEY")
+	if acc0Key == "" {
+		t.Skip("skipping: set TEST_PRIVATE_KEY env var")
+	}
+
+	privateKey, err := crypto.HexToECDSA(acc0Key)
+	if err != nil {
+		t.Fatalf("invalid private key: %v", err)
+	}
+
+	_, err = sendRegisterTx(
+		rpcURL,
+		SHINZO_HUB_PRECOMPILED_VIEW_REGISTRY_ADDRESS,
+		privateKey,
+		[]byte("INVALID_VWL_DATA"),
+	)
+
+	if err == nil {
+		t.Fatal("expected sendRegisterTx to return error for invalid payload, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "reverted") {
+		t.Errorf("expected error to mention 'reverted', got: %s", err.Error())
+	}
+
+	t.Logf("correctly returned error: %v", err)
+}

--- a/core/service/mock.go
+++ b/core/service/mock.go
@@ -1,2464 +1,524 @@
 package service
 
-const GQL = `
-mutation {
-  b1: create_Block(input: {
-    hash: "0x71722f244f58d669cbee3772a077021721a278f64f7fd633dbdde131ca3766e4",
-    number: 20483210,
-    timestamp: "2023-07-01T12:00:00Z",
-    parentHash: "0x30877432d1026706d7e805da846a32c3bb81e3c29b62179273c8eb5bb682575e",
-    difficulty: "999900",
-    gasUsed: "19155998",
+import (
+	"fmt"
+	"strings"
+)
+
+const GQL_BLOCKS = `mutation {
+  b1: add_Ethereum__Mainnet__Block(input: {
+    hash: "0x4e3a3754410177e6937ef1f84bba68ea139e8d1a2258c5f85db9f1cd715a1bdd",
+    number: 18500000,
+    timestamp: "2023-11-01T12:00:00Z",
+    parentHash: "0x3c2a2d4a5c1e8f6b9d7e0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d",
+    difficulty: "0",
+    gasUsed: "12000000",
     gasLimit: "30000000",
-    nonce: "0x5227c3712da86a78",
-    miner: "0x58e72e310275dff6c15c0c8e9df469611a11f512",
-    size: "1405",
-    stateRoot: "0xaac8d82f01b7210760474f36e8b5359309cc6273931bdb2a0df3dbe4d58fed8a",
-    sha3Uncles: "0x49ea20e32684b27b95e909348334896a68f812d810a485ed03241b4d419b1b67",
-    transactionsRoot: "0x3bd4755d05ad7853c1f76eb97706ca828bca0385813dbad3c681d06bd2aa399d",
-    receiptsRoot: "0xac946dc59c0996daeee6f529a279764017f2ed6cfc7403d75e173e4eaede5fe8",
-    extraData: "0x78f78e2978aa2447c462ddaed16dc0cf0b9cd7f78df0cac5e40c02d4e518ca6e"
+    nonce: "0x0000000000000000",
+    miner: "0x388C818CA8B9251b393131C08a736A67ccB19297",
+    size: "1200",
+    stateRoot: "0xabc123def456789abc123def456789abc123def456789abc123def456789abcd",
+    sha3Uncles: "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+    transactionsRoot: "0x5678abcdef1234567890abcdef1234567890abcdef1234567890abcdef123456",
+    receiptsRoot: "0x9876fedcba0987654321fedcba0987654321fedcba0987654321fedcba098765",
+    extraData: "0x"
   }) { hash }
 
-  t1_1: create_Transaction(input: {
-    hash: "0x728e7eca0fa5f6b8a880627df7ffe0297c79bfbdabe898736a3566f893697b59",
-    blockHash: "0x71722f244f58d669cbee3772a077021721a278f64f7fd633dbdde131ca3766e4",
-    blockNumber: 20483210,
-    from: "0x0481194f309ffea518f32cf21449273d7cee9d91",
-    to: "0x36682575250def91799e2786d3748421599e3e9c",
-    value: "500",
-    gasUsed: "152195",
-    gasPrice: "45000000000",
-    inputData: "0xe21da80270815fe85df2fbdaa35adf9c1e2a8a3c0ed16bfe16849ef307590d2",
-    nonce: "57",
-    transactionIndex: "0",
-    r: "0x3e34f98dff7e4c6428da8099f4efbacea67c7d1afcc4f14a3e3e04d42f8ac2ac",
-    s: "0xaf127972d33e5901a19bbd47d5552c7f47e8e80e952eb9d8e96cf37cb990c801",
-    v: "0x1c"
-  }) { hash }
-
-  l1_1_1: create_Log(input: {
-    address: "0x7b7684319e1b429ad564b858f9a3e247cb2c083e",
-    topics: ["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", "0x8cb37f0a72e9d34119f3374cebd4d3fd81b6ee7b3bb1c863e2601a7462667a40", "0x844853040b7a05814d32feb3e719e01fcd3fe22a4248ac9ed336de7daecd3ada"],
-    data: "0xb4f2222d3b41a3dbd199b364f73bb387d080589ab054c24026cdea5b9a2145128edfed863bd39f917c10696489a30fd5",
-    transactionHash: "0x728e7eca0fa5f6b8a880627df7ffe0297c79bfbdabe898736a3566f893697b59",
-    blockHash: "0x71722f244f58d669cbee3772a077021721a278f64f7fd633dbdde131ca3766e4",
-    blockNumber: 20483210,
-    transactionIndex: "0",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e1_1_1: create_Event(input: {
-    contractAddress: "0x7b7684319e1b429ad564b858f9a3e247cb2c083e",
-    eventName: "Approval",
-    parameters: "{\"owner\":\"0x0481194f309ffea518f32cf21449273d7cee9d91\",\"spender\":\"0x36682575250def91799e2786d3748421599e3e9c\",\"value\":\"500\"}",
-    transactionHash: "0x728e7eca0fa5f6b8a880627df7ffe0297c79bfbdabe898736a3566f893697b59",
-    blockHash: "0x71722f244f58d669cbee3772a077021721a278f64f7fd633dbdde131ca3766e4",
-    blockNumber: 20483210,
-    transactionIndex: "0",
-    logIndex: "0"
-  }) { eventName }
-
-  t1_2: create_Transaction(input: {
-    hash: "0x4c7b2c1d0e2adcd93c0a5eb2d37dc2c9a7a5236bb4734865425feeaa4e2fe981",
-    blockHash: "0x71722f244f58d669cbee3772a077021721a278f64f7fd633dbdde131ca3766e4",
-    blockNumber: 20483210,
-    from: "0xb29ee11b922ce1e6af41e3a2517ee5bb9cda1a2a",
-    to: "0x3c984a24b9c429ca42db0b956af67442931a4c45",
-    value: "10",
-    gasUsed: "238932",
-    gasPrice: "60000000000",
-    inputData: "0xe1db7e9e779f6bee9cd56",
-    nonce: "154",
-    transactionIndex: "1",
-    r: "0x481fb339258e4d27eb0d1cb7c2b70a3a4419f4fe020864d3979317de23f0749d",
-    s: "0x0b7d52b20cf1cb80b2b73a41ba5ef542e196161a9cf8169b1a83bdceca5ffb82",
-    v: "0x1c"
-  }) { hash }
-
-  t1_3: create_Transaction(input: {
-    hash: "0xd59a32a99ed5ebe1bd812cb504e1427bbc14ebbe24bca87305fc388e69f6342e",
-    blockHash: "0x71722f244f58d669cbee3772a077021721a278f64f7fd633dbdde131ca3766e4",
-    blockNumber: 20483210,
-    from: "0x5e2ab29955b73647f0bbe4229cfdd24a2eeb454d",
-    to: "0x134955a7b92868492545a102186d0f99f7c9e215",
-    value: "10000",
-    gasUsed: "129952",
-    gasPrice: "30000000000",
-    inputData: "0x6a4aabc4b3a7e38e74319cd75aa65fef9f02ce76b119ff903d48bcb1c16",
-    nonce: "92",
-    transactionIndex: "2",
-    r: "0x92ce8343cbab46c1114afe44aa5c9af9f0ba3d90f871f5c471360ead4d6df146",
-    s: "0xafca5eab8f67897996fafb893ccb49192be8f6688437717713daf3405dff69a9",
-    v: "0x1b"
-  }) { hash }
-
-  t1_4: create_Transaction(input: {
-    hash: "0x715d51cf591093a9ef4e863a5e850a965cda2c354fa708c7e8a908b713e95c93",
-    blockHash: "0x71722f244f58d669cbee3772a077021721a278f64f7fd633dbdde131ca3766e4",
-    blockNumber: 20483210,
-    from: "0x9b774f4ebdf672eb231645ae36f2e1e4de1e90c8",
-    to: "0x0621db212f19d54dbcecc24b35c47009edc77eb4",
-    value: "500",
-    gasUsed: "70409",
-    gasPrice: "10000000000",
-    inputData: "0xd076",
-    nonce: "17",
-    transactionIndex: "3",
-    r: "0x31e171ce761497aa7947d9815df1bcadd49c5f7794e1dd4c786a2eb2618c1266",
-    s: "0xf6a90663f76c7a9ceb98bfe3fa6bad17408d946a7c7fa8ffe5b54f511210d472",
-    v: "0x1b"
-  }) { hash }
-
-  t1_5: create_Transaction(input: {
-    hash: "0x6eb1ff00d00890d5334768b8c2bce779212cccf1052fda3176f812815a064c29",
-    blockHash: "0x71722f244f58d669cbee3772a077021721a278f64f7fd633dbdde131ca3766e4",
-    blockNumber: 20483210,
-    from: "0x57cac42b13d72aca08ef7bcd5c2972284c4cab32",
-    to: "0x09eb83425ded302b2ac09dc275c54898f425d8d9",
-    value: "10000",
-    gasUsed: "226171",
-    gasPrice: "10000000000",
-    inputData: "0x87f6e3490cacaead49a6fa5ca9f7ac8cb3650e6e92df49",
-    nonce: "61",
-    transactionIndex: "4",
-    r: "0x84dc2efcd1b237b51cad303877ebce4b0f39d234b9ae6fbf3eea29130a35755a",
-    s: "0xde7c55dc06edc0668235ba6e38facc3bbe5924a37935b4cd4cd5f55f945ae1b0",
-    v: "0x1c"
-  }) { hash }
-
-  l1_5_1: create_Log(input: {
-    address: "0x6cfdfdef5207918795ef338b1e6d3791e8b2e376",
-    topics: ["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", "0xd54661b85a99834d184474a7cf48dce22c8befa02eb2c6d6f8a9a4fa113e035e", "0xe0d649582b82b51c97d2306f247e00a3d4f27c233ab94c44205eb64de62343cb"],
-    data: "0xa4782790966c917fc37f20ba4cdb5f20208611c9ddc24829264ac29d7172d3e19530405fb85b4830ad8282feb1f5b5833701071fbc451d7a7da82b",
-    transactionHash: "0x6eb1ff00d00890d5334768b8c2bce779212cccf1052fda3176f812815a064c29",
-    blockHash: "0x71722f244f58d669cbee3772a077021721a278f64f7fd633dbdde131ca3766e4",
-    blockNumber: 20483210,
-    transactionIndex: "4",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e1_5_1: create_Event(input: {
-    contractAddress: "0x6cfdfdef5207918795ef338b1e6d3791e8b2e376",
-    eventName: "Approval",
-    parameters: "{\"owner\":\"0x57cac42b13d72aca08ef7bcd5c2972284c4cab32\",\"spender\":\"0x09eb83425ded302b2ac09dc275c54898f425d8d9\",\"value\":\"10000\"}",
-    transactionHash: "0x6eb1ff00d00890d5334768b8c2bce779212cccf1052fda3176f812815a064c29",
-    blockHash: "0x71722f244f58d669cbee3772a077021721a278f64f7fd633dbdde131ca3766e4",
-    blockNumber: 20483210,
-    transactionIndex: "4",
-    logIndex: "0"
-  }) { eventName }
-
-  t1_6: create_Transaction(input: {
-    hash: "0x31571c2e99a2e0b6997ebf6740d07b0a0c9367df148217dbe234c21d4798acaa",
-    blockHash: "0x71722f244f58d669cbee3772a077021721a278f64f7fd633dbdde131ca3766e4",
-    blockNumber: 20483210,
-    from: "0xe872643435eead3b6e9e8325916a427bc19850ce",
-    to: "0x73e34301746cb282026e42a31e15dcf0cd5b6588",
-    value: "10000",
-    gasUsed: "59962",
-    gasPrice: "8000000000",
-    inputData: "0x9fdf128c4d670cbffbac850a7081fb7",
-    nonce: "40",
-    transactionIndex: "5",
-    r: "0x377817cb557ab0b46f95f121770f0a64a5a10443b2bc3a9a45dfa5b75c99450c",
-    s: "0x15a73f4a27ba52ae08672b8301ced5dfcbc3f75e2190a832a5c522af0d5d513a",
-    v: "0x1b"
-  }) { hash }
-
-  l1_6_1: create_Log(input: {
-    address: "0xd899731cf41b0d29f6306592f39cff82c5bcb5e1",
-    topics: ["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", "0xee8781432bd71cdf7f92c143e556641d2d648a22cca8e0d3d443339bd8cff158", "0xc4c1ca71f8b0a998f3749ea8d26e6dfb1529c40566171e1b68bec307bfe5fbb5"],
-    data: "0x290c1567768d00f4507898dcbe86e9c30b993f2a8a8896471ca40f98dcc16a7fb95593f485a27b79dab89e3f12f63c9d1",
-    transactionHash: "0x31571c2e99a2e0b6997ebf6740d07b0a0c9367df148217dbe234c21d4798acaa",
-    blockHash: "0x71722f244f58d669cbee3772a077021721a278f64f7fd633dbdde131ca3766e4",
-    blockNumber: 20483210,
-    transactionIndex: "5",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e1_6_1: create_Event(input: {
-    contractAddress: "0xd899731cf41b0d29f6306592f39cff82c5bcb5e1",
-    eventName: "Approval",
-    parameters: "{\"owner\":\"0xe872643435eead3b6e9e8325916a427bc19850ce\",\"spender\":\"0x73e34301746cb282026e42a31e15dcf0cd5b6588\",\"value\":\"10000\"}",
-    transactionHash: "0x31571c2e99a2e0b6997ebf6740d07b0a0c9367df148217dbe234c21d4798acaa",
-    blockHash: "0x71722f244f58d669cbee3772a077021721a278f64f7fd633dbdde131ca3766e4",
-    blockNumber: 20483210,
-    transactionIndex: "5",
-    logIndex: "0"
-  }) { eventName }
-
-  t1_7: create_Transaction(input: {
-    hash: "0x446ade4a52fa5a10e8655f24ddcdfc016b0a60077b943c952199ead4afb65c07",
-    blockHash: "0x71722f244f58d669cbee3772a077021721a278f64f7fd633dbdde131ca3766e4",
-    blockNumber: 20483210,
-    from: "0x746053b1c8113013dec38f4609d384d33933f668",
-    to: "0x6bd951f6fa70023f422387e98e13519bad331045",
-    value: "1000",
-    gasUsed: "114723",
-    gasPrice: "30000000000",
-    inputData: "0x2ba53cce8cfd534153dfe5cb04ff3de128",
-    nonce: "167",
-    transactionIndex: "6",
-    r: "0xa07a3d7fbc4105ff52fa7a817cc72eee2fea3f03cd10296eab17eafbe3370ab9",
-    s: "0xb315f4d38663c6e6a3d13ee4f01df5543cacd78ca9e44d9a6669b45a3bfd9d03",
-    v: "0x1b"
-  }) { hash }
-
-  l1_7_1: create_Log(input: {
-    address: "0x4116859841961be37c791ccda1086e7b669e5255",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0xc1d884580ae414a19fb2a7525dc2b76aab96f03be771ac3c890bef196a235026", "0x6d36d240ea122158278dcecda0c30212b39929ecc0f574c949b04310c296b6d4"],
-    data: "0x5786351e292836fab473926afea94bad50a77d8b4afeeb9f35284682200c618f4bc794e2cb0754e554fb",
-    transactionHash: "0x446ade4a52fa5a10e8655f24ddcdfc016b0a60077b943c952199ead4afb65c07",
-    blockHash: "0x71722f244f58d669cbee3772a077021721a278f64f7fd633dbdde131ca3766e4",
-    blockNumber: 20483210,
-    transactionIndex: "6",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e1_7_1: create_Event(input: {
-    contractAddress: "0x4116859841961be37c791ccda1086e7b669e5255",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0x746053b1c8113013dec38f4609d384d33933f668\",\"to\":\"0x6bd951f6fa70023f422387e98e13519bad331045\",\"value\":\"1000\"}",
-    transactionHash: "0x446ade4a52fa5a10e8655f24ddcdfc016b0a60077b943c952199ead4afb65c07",
-    blockHash: "0x71722f244f58d669cbee3772a077021721a278f64f7fd633dbdde131ca3766e4",
-    blockNumber: 20483210,
-    transactionIndex: "6",
-    logIndex: "0"
-  }) { eventName }
-
-  l1_7_2: create_Log(input: {
-    address: "0x17f728b716bcfe11a3885ccb28c7cbbff04e5728",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0x455b37da3fff65d071454141585c0926eff57d4585ae27cc4306d435f132f40d", "0xdb1d7fcb3d48f729d860030c6adb34d88db8c6df5bf89bc437e536ca15c024fd"],
-    data: "0x287b21cc915fe06961751b70528cbcc60229bb876ec085d329a388ecf7aee0f382c77adb087",
-    transactionHash: "0x446ade4a52fa5a10e8655f24ddcdfc016b0a60077b943c952199ead4afb65c07",
-    blockHash: "0x71722f244f58d669cbee3772a077021721a278f64f7fd633dbdde131ca3766e4",
-    blockNumber: 20483210,
-    transactionIndex: "6",
-    logIndex: "1",
-    removed: "false"
-  }) { address }
-
-  e1_7_2: create_Event(input: {
-    contractAddress: "0x17f728b716bcfe11a3885ccb28c7cbbff04e5728",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0x746053b1c8113013dec38f4609d384d33933f668\",\"to\":\"0x6bd951f6fa70023f422387e98e13519bad331045\",\"value\":\"1000\"}",
-    transactionHash: "0x446ade4a52fa5a10e8655f24ddcdfc016b0a60077b943c952199ead4afb65c07",
-    blockHash: "0x71722f244f58d669cbee3772a077021721a278f64f7fd633dbdde131ca3766e4",
-    blockNumber: 20483210,
-    transactionIndex: "6",
-    logIndex: "1"
-  }) { eventName }
-
-  t1_8: create_Transaction(input: {
-    hash: "0x92ca25fab6856f67786767b4332f01fbaf8f58c741df1bc5e3ea006c3ab85878",
-    blockHash: "0x71722f244f58d669cbee3772a077021721a278f64f7fd633dbdde131ca3766e4",
-    blockNumber: 20483210,
-    from: "0xfab5fd6dbbc8e547387dc644f05df4af981c3516",
-    to: "0x8f3ea8bb8b0d3b659bafe2c9e45adc225a7aa98c",
-    value: "500",
-    gasUsed: "137627",
-    gasPrice: "20000000000",
-    inputData: "0xd550478265c332f10c23842c9779e44501bafe8e45ed9bf72e9bd8490",
-    nonce: "0",
-    transactionIndex: "7",
-    r: "0x4b9f0ff90d970b6ddc75cc782d7898d625493ee8f6a041053984e07240f6ad9f",
-    s: "0xbe1a2418c2f568c037ce716e36fc9a5138f96b1637da0583c701f4b275f2a11b",
-    v: "0x1b"
-  }) { hash }
-
-  l1_8_1: create_Log(input: {
-    address: "0x34f7abe60cb481fe9f65bae8524e98be0c50b7a2",
-    topics: ["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", "0x6f49ada332145163f631cf81b7206f2e1bdb1812926337c6675d3bed355ca5eb", "0xaabdda76c8beec0190490976a08431eb448b77892c62af5f391c21abdd370c19"],
-    data: "0xa4a741ce27d9c44a2f1c82cd44f6fc67728da23ddbb6ab095be4e176b42317490a39e",
-    transactionHash: "0x92ca25fab6856f67786767b4332f01fbaf8f58c741df1bc5e3ea006c3ab85878",
-    blockHash: "0x71722f244f58d669cbee3772a077021721a278f64f7fd633dbdde131ca3766e4",
-    blockNumber: 20483210,
-    transactionIndex: "7",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e1_8_1: create_Event(input: {
-    contractAddress: "0x34f7abe60cb481fe9f65bae8524e98be0c50b7a2",
-    eventName: "Approval",
-    parameters: "{\"owner\":\"0xfab5fd6dbbc8e547387dc644f05df4af981c3516\",\"spender\":\"0x8f3ea8bb8b0d3b659bafe2c9e45adc225a7aa98c\",\"value\":\"500\"}",
-    transactionHash: "0x92ca25fab6856f67786767b4332f01fbaf8f58c741df1bc5e3ea006c3ab85878",
-    blockHash: "0x71722f244f58d669cbee3772a077021721a278f64f7fd633dbdde131ca3766e4",
-    blockNumber: 20483210,
-    transactionIndex: "7",
-    logIndex: "0"
-  }) { eventName }
-
-  l1_8_2: create_Log(input: {
-    address: "0xf0a6668f40c18519681e02c8b309c7c3af256e01",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0x9afc50bbb97818c0874ac42c7d74d9ae4646494d45a235a40add9e8463450877", "0x70b2f4fb5cff45671d08d76625efae7dc1cac13ee17c1c169ec99e5d914ee235"],
-    data: "0xcdae05e6e28a5323eb2c5cc15a45451d99e95346080eff0f76fede207861541b1419a213d5595eb12",
-    transactionHash: "0x92ca25fab6856f67786767b4332f01fbaf8f58c741df1bc5e3ea006c3ab85878",
-    blockHash: "0x71722f244f58d669cbee3772a077021721a278f64f7fd633dbdde131ca3766e4",
-    blockNumber: 20483210,
-    transactionIndex: "7",
-    logIndex: "1",
-    removed: "false"
-  }) { address }
-
-  e1_8_2: create_Event(input: {
-    contractAddress: "0xf0a6668f40c18519681e02c8b309c7c3af256e01",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0xfab5fd6dbbc8e547387dc644f05df4af981c3516\",\"to\":\"0x8f3ea8bb8b0d3b659bafe2c9e45adc225a7aa98c\",\"value\":\"500\"}",
-    transactionHash: "0x92ca25fab6856f67786767b4332f01fbaf8f58c741df1bc5e3ea006c3ab85878",
-    blockHash: "0x71722f244f58d669cbee3772a077021721a278f64f7fd633dbdde131ca3766e4",
-    blockNumber: 20483210,
-    transactionIndex: "7",
-    logIndex: "1"
-  }) { eventName }
-
-  l1_8_3: create_Log(input: {
-    address: "0x9abc2d29f438ad66132f9da8b4fff5796030e36d",
-    topics: ["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", "0x1ab60698299a03aac056aaff14f4eaed19a06ab2480ac5c539a18d2f7be96953", "0xb162e0f46af9a43461ec30912ae139096a6698ae384583036ba8497529ae140f"],
-    data: "0x3c12dc5eb9a62e42e3e9ef7748bc5aaef02f3bfe59b43c3a29ecd775fc2a6dda752f3e",
-    transactionHash: "0x92ca25fab6856f67786767b4332f01fbaf8f58c741df1bc5e3ea006c3ab85878",
-    blockHash: "0x71722f244f58d669cbee3772a077021721a278f64f7fd633dbdde131ca3766e4",
-    blockNumber: 20483210,
-    transactionIndex: "7",
-    logIndex: "2",
-    removed: "false"
-  }) { address }
-
-  e1_8_3: create_Event(input: {
-    contractAddress: "0x9abc2d29f438ad66132f9da8b4fff5796030e36d",
-    eventName: "Approval",
-    parameters: "{\"owner\":\"0xfab5fd6dbbc8e547387dc644f05df4af981c3516\",\"spender\":\"0x8f3ea8bb8b0d3b659bafe2c9e45adc225a7aa98c\",\"value\":\"500\"}",
-    transactionHash: "0x92ca25fab6856f67786767b4332f01fbaf8f58c741df1bc5e3ea006c3ab85878",
-    blockHash: "0x71722f244f58d669cbee3772a077021721a278f64f7fd633dbdde131ca3766e4",
-    blockNumber: 20483210,
-    transactionIndex: "7",
-    logIndex: "2"
-  }) { eventName }
-
-  t1_9: create_Transaction(input: {
-    hash: "0xa3e59c23caf1264044e9ce66a99db20c491b10b3907dcacccd65f46cbd494402",
-    blockHash: "0x71722f244f58d669cbee3772a077021721a278f64f7fd633dbdde131ca3766e4",
-    blockNumber: 20483210,
-    from: "0x04fd424ded5edecb75d0f78db11fb3f248e227f2",
-    to: "0x91a0fefadb9951981f51909f2428848880354eb5",
-    value: "500",
-    gasUsed: "226134",
-    gasPrice: "15000000000",
-    inputData: "0x51a244fdc7e56b18315ecf9f7ccf84d09eca13bd8a8838ce76a5a0020d33eb",
-    nonce: "56",
-    transactionIndex: "8",
-    r: "0x986102163324c53589e2e8da85281cca1885e2f6c5f34d63e831228e0f401c84",
-    s: "0xac0ffdc270cf3ba9c12ba2e9651c69c3bf2e641607fc29fe01a1a1c36e47214f",
-    v: "0x1b"
-  }) { hash }
-
-  l1_9_1: create_Log(input: {
-    address: "0x17405193e5233f726daca34a615a2384d5b5e714",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0xc50f200529df4648ed7515f29bd07633b7e681634ff5511b96d8ae131550f327", "0xead6a73a737d6c72ff1d46e5cb4e6b86a411843eed5a795572df6fe80d77ad74"],
-    data: "0xd11f1dcf3ef720d64b9720f95e0ee4c5be02ca19d862a1b13cbe1bb5264a73f6",
-    transactionHash: "0xa3e59c23caf1264044e9ce66a99db20c491b10b3907dcacccd65f46cbd494402",
-    blockHash: "0x71722f244f58d669cbee3772a077021721a278f64f7fd633dbdde131ca3766e4",
-    blockNumber: 20483210,
-    transactionIndex: "8",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e1_9_1: create_Event(input: {
-    contractAddress: "0x17405193e5233f726daca34a615a2384d5b5e714",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0x04fd424ded5edecb75d0f78db11fb3f248e227f2\",\"to\":\"0x91a0fefadb9951981f51909f2428848880354eb5\",\"value\":\"500\"}",
-    transactionHash: "0xa3e59c23caf1264044e9ce66a99db20c491b10b3907dcacccd65f46cbd494402",
-    blockHash: "0x71722f244f58d669cbee3772a077021721a278f64f7fd633dbdde131ca3766e4",
-    blockNumber: 20483210,
-    transactionIndex: "8",
-    logIndex: "0"
-  }) { eventName }
-
-  l1_9_2: create_Log(input: {
-    address: "0x7ab8d812bbef3f9eb26e22c59235834f4609d4fb",
-    topics: ["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", "0xe096207adaafee949587fb914b9e5595545731a4e8b561ab4be5930cf4ea40a9", "0xf94ea3f14390c7eb2a1678602e2c6fa1bc4dbcb09bb9e26ede95dd42469fa2c2"],
-    data: "0xd8d5e465c9f199fe700489f39d5f7038f2bfd8f3b08514ae4b518bdb19926535",
-    transactionHash: "0xa3e59c23caf1264044e9ce66a99db20c491b10b3907dcacccd65f46cbd494402",
-    blockHash: "0x71722f244f58d669cbee3772a077021721a278f64f7fd633dbdde131ca3766e4",
-    blockNumber: 20483210,
-    transactionIndex: "8",
-    logIndex: "1",
-    removed: "false"
-  }) { address }
-
-  e1_9_2: create_Event(input: {
-    contractAddress: "0x7ab8d812bbef3f9eb26e22c59235834f4609d4fb",
-    eventName: "Approval",
-    parameters: "{\"owner\":\"0x04fd424ded5edecb75d0f78db11fb3f248e227f2\",\"spender\":\"0x91a0fefadb9951981f51909f2428848880354eb5\",\"value\":\"500\"}",
-    transactionHash: "0xa3e59c23caf1264044e9ce66a99db20c491b10b3907dcacccd65f46cbd494402",
-    blockHash: "0x71722f244f58d669cbee3772a077021721a278f64f7fd633dbdde131ca3766e4",
-    blockNumber: 20483210,
-    transactionIndex: "8",
-    logIndex: "1"
-  }) { eventName }
-
-  t1_10: create_Transaction(input: {
-    hash: "0xaa98b3b4049bfda5364763de2340fb9b4ea5903744794642d320fd16311f3812",
-    blockHash: "0x71722f244f58d669cbee3772a077021721a278f64f7fd633dbdde131ca3766e4",
-    blockNumber: 20483210,
-    from: "0x9033665b0248bb572306695036fb5e35bcd67d3a",
-    to: "0x3e34fb912af3c9e9e7d9d62fb50f3ce234cc352b",
-    value: "100",
-    gasUsed: "109770",
-    gasPrice: "15000000000",
-    inputData: "0x37df88cbfcf84e338ff740312f05ca4932fe69ff8a01d3ceace",
-    nonce: "117",
-    transactionIndex: "9",
-    r: "0x11595fd49cf3fff51c8fcb9a1014bb0ac3dbbdb177792293a50a1edd80f0acca",
-    s: "0x3f36afa59bd6f269819c723a82fd6b299da6dc8e505f6e8d16be4749dda26d89",
-    v: "0x1b"
-  }) { hash }
-
-  l1_10_1: create_Log(input: {
-    address: "0x7c7346079efdd1658408851f012a92db2c47338f",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0x73aac7d643568ed81fb3adf784bfb901178c9b37ec0c8927965ead182ffdad35", "0x82bdae015e40c69a23574daef485a962db5cc70072e6851cd842b530def37668"],
-    data: "0xfc4d6696d5d40987e7be20f4ac6cd82311a7fb108c9cb41585fae42ad483a14f8bd988ad5af4e1641751f85ed3f1ebfef343",
-    transactionHash: "0xaa98b3b4049bfda5364763de2340fb9b4ea5903744794642d320fd16311f3812",
-    blockHash: "0x71722f244f58d669cbee3772a077021721a278f64f7fd633dbdde131ca3766e4",
-    blockNumber: 20483210,
-    transactionIndex: "9",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e1_10_1: create_Event(input: {
-    contractAddress: "0x7c7346079efdd1658408851f012a92db2c47338f",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0x9033665b0248bb572306695036fb5e35bcd67d3a\",\"to\":\"0x3e34fb912af3c9e9e7d9d62fb50f3ce234cc352b\",\"value\":\"100\"}",
-    transactionHash: "0xaa98b3b4049bfda5364763de2340fb9b4ea5903744794642d320fd16311f3812",
-    blockHash: "0x71722f244f58d669cbee3772a077021721a278f64f7fd633dbdde131ca3766e4",
-    blockNumber: 20483210,
-    transactionIndex: "9",
-    logIndex: "0"
-  }) { eventName }
-
-  b2: create_Block(input: {
-    hash: "0xb269558605d27f3a093cb3a402efe80a1ea4619a12c2c857c2065cc9439fd94b",
-    number: 20483211,
-    timestamp: "2023-07-01T12:02:00Z",
-    parentHash: "0x71722f244f58d669cbee3772a077021721a278f64f7fd633dbdde131ca3766e4",
-    difficulty: "1000900",
-    gasUsed: "8224966",
+  b2: add_Ethereum__Mainnet__Block(input: {
+    hash: "0x5f4b4865521288f7a48ef2f95bba69ea239f9d2b3369d6f96eb9f2de826b2cee",
+    number: 18500001,
+    timestamp: "2023-11-01T12:00:12Z",
+    parentHash: "0x4e3a3754410177e6937ef1f84bba68ea139e8d1a2258c5f85db9f1cd715a1bdd",
+    difficulty: "0",
+    gasUsed: "15000000",
     gasLimit: "30000000",
-    nonce: "0x3e8b8203e55c12d9",
-    miner: "0xb6fecf8d2db5dd21ae74f29ed2f94497d91213dd",
-    size: "1321",
-    stateRoot: "0x4c73a6be34dd221d4f6e2bcc8fdefd544fe436ef15b3d33b9143b9b99f044d19",
-    sha3Uncles: "0xee8a565283d00c305fecf9bc92440630606f47d629e4fd0354eff0e769c1a03d",
-    transactionsRoot: "0xdf91fcff710da28df3fbed0596fbe77ae49cdbf5692f4565f3df97610b8b5512",
-    receiptsRoot: "0xad3737f8ab18431ee33313536b59ef34ba436ed07fa9528bdb74d74dddeb0e40",
-    extraData: "0x22aac5d1c1419dc9ab084ce6ebc6921ac49629a500879d31b8b313e90ea77b99"
+    nonce: "0x0000000000000000",
+    miner: "0x1f9090aaE28b8a3dCeaDf281B0F12828e676c326",
+    size: "1350",
+    stateRoot: "0xdef456789abc123def456789abc123def456789abc123def456789abc123def4",
+    sha3Uncles: "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+    transactionsRoot: "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+    receiptsRoot: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+    extraData: "0x"
   }) { hash }
 
-  t2_1: create_Transaction(input: {
-    hash: "0x965f03b21df9eacf44eee4a2dc7ca1e8250932616f0350867e2ac1f0ad5d0ac8",
-    blockHash: "0xb269558605d27f3a093cb3a402efe80a1ea4619a12c2c857c2065cc9439fd94b",
-    blockNumber: 20483211,
-    from: "0x23359458249d51a5019c3a4da8c31677fc381aed",
-    to: "0x2f0d7083749de264b57de10e9501f88cb6915292",
-    value: "2500",
-    gasUsed: "204089",
-    gasPrice: "10000000000",
-    inputData: "0x8d6aa8e87aa6ea040",
-    nonce: "155",
-    transactionIndex: "0",
-    r: "0xf005dfc220e3bcbc503eb6e0708b62977fb18f606c38f5652424878608e0d1ad",
-    s: "0xd83efb1718dea0c6a207d2765a9230fd0a873f7a1a72e3e3211ca241e19d2311",
-    v: "0x1c"
-  }) { hash }
-
-  l2_1_1: create_Log(input: {
-    address: "0xc3d70eced3a0ea63302648bdfe5741149db944f9",
-    topics: ["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", "0x9b04171db6662a6feaa9da53e1f7077e67fac6c50b02b0349e6b106695785a75", "0x6058304c3a69e7bb5d234466cbad71694a7184f62f25cbfe5abfff8c1676e7c6"],
-    data: "0xdc5b82429eb71eadeeddbfa8c05e782b29287332b16a6a898648099bcc0f4c776f7eea2a6dd6ee0b4490fba7ddc9a0144acc6c2",
-    transactionHash: "0x965f03b21df9eacf44eee4a2dc7ca1e8250932616f0350867e2ac1f0ad5d0ac8",
-    blockHash: "0xb269558605d27f3a093cb3a402efe80a1ea4619a12c2c857c2065cc9439fd94b",
-    blockNumber: 20483211,
-    transactionIndex: "0",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e2_1_1: create_Event(input: {
-    contractAddress: "0xc3d70eced3a0ea63302648bdfe5741149db944f9",
-    eventName: "Approval",
-    parameters: "{\"owner\":\"0x23359458249d51a5019c3a4da8c31677fc381aed\",\"spender\":\"0x2f0d7083749de264b57de10e9501f88cb6915292\",\"value\":\"2500\"}",
-    transactionHash: "0x965f03b21df9eacf44eee4a2dc7ca1e8250932616f0350867e2ac1f0ad5d0ac8",
-    blockHash: "0xb269558605d27f3a093cb3a402efe80a1ea4619a12c2c857c2065cc9439fd94b",
-    blockNumber: 20483211,
-    transactionIndex: "0",
-    logIndex: "0"
-  }) { eventName }
-
-  l2_1_2: create_Log(input: {
-    address: "0xc6f3ae925351f0562c96792e1b05adc534df2c64",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0x9df596e8604e2c7afee129eb9c5d75dec53c1758926fd3b23ade5861e02ecac6", "0xc10834aefe227e4f85503593c52084eb5616e13c9e101c67b7620d00a6273551"],
-    data: "0x3aa66cd3763ba50ca0c6e728b126d9f3583ac4a5af2a0ec7070397d7214bf964c617ea48a1d907aa76177ca5e02f26146425672de9567d5799e68",
-    transactionHash: "0x965f03b21df9eacf44eee4a2dc7ca1e8250932616f0350867e2ac1f0ad5d0ac8",
-    blockHash: "0xb269558605d27f3a093cb3a402efe80a1ea4619a12c2c857c2065cc9439fd94b",
-    blockNumber: 20483211,
-    transactionIndex: "0",
-    logIndex: "1",
-    removed: "false"
-  }) { address }
-
-  e2_1_2: create_Event(input: {
-    contractAddress: "0xc6f3ae925351f0562c96792e1b05adc534df2c64",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0x23359458249d51a5019c3a4da8c31677fc381aed\",\"to\":\"0x2f0d7083749de264b57de10e9501f88cb6915292\",\"value\":\"2500\"}",
-    transactionHash: "0x965f03b21df9eacf44eee4a2dc7ca1e8250932616f0350867e2ac1f0ad5d0ac8",
-    blockHash: "0xb269558605d27f3a093cb3a402efe80a1ea4619a12c2c857c2065cc9439fd94b",
-    blockNumber: 20483211,
-    transactionIndex: "0",
-    logIndex: "1"
-  }) { eventName }
-
-  t2_2: create_Transaction(input: {
-    hash: "0xf2bcc5fedd4f0cd29458ce9e9cf2a4f64600bfcdcbcf92d13c56d8bfb1cd77f1",
-    blockHash: "0xb269558605d27f3a093cb3a402efe80a1ea4619a12c2c857c2065cc9439fd94b",
-    blockNumber: 20483211,
-    from: "0xb048e4875032cc26d5d89c9d23b486c905f032dd",
-    to: "0x9d55b546f53e6561568de35292c382a07ff30180",
-    value: "0",
-    gasUsed: "46386",
-    gasPrice: "15000000000",
-    inputData: "0x",
-    nonce: "96",
-    transactionIndex: "1",
-    r: "0x8ffadabaa7bcc1ba30ec40387befd60a0b1ae7fc2bdf3c96414f29e5e3f77652",
-    s: "0x3d05ac878f34f2a72accd77839232a63b4ac0916cdab473c0ea497fe4941a938",
-    v: "0x1c"
-  }) { hash }
-
-  l2_2_1: create_Log(input: {
-    address: "0x6f9c1a46715fc950cadfbcc2996c34a19e54ef94",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0x660b34cd513bf513ad4c7137cf95c2ec8eb03323f70f835cfd943a25c0cf2363", "0x550ea31465281239b5d07919e4fab63171649646b84d288c5ce28d46286b5d4a"],
-    data: "0xc072833d2a2ba847803c7c3359f3b98315ac5bcf480444c81b7de5ebe98d7929da222725129f0d4ff3c060db71e5752b4b1dfc5b3a7399f9860c691",
-    transactionHash: "0xf2bcc5fedd4f0cd29458ce9e9cf2a4f64600bfcdcbcf92d13c56d8bfb1cd77f1",
-    blockHash: "0xb269558605d27f3a093cb3a402efe80a1ea4619a12c2c857c2065cc9439fd94b",
-    blockNumber: 20483211,
-    transactionIndex: "1",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e2_2_1: create_Event(input: {
-    contractAddress: "0x6f9c1a46715fc950cadfbcc2996c34a19e54ef94",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0xb048e4875032cc26d5d89c9d23b486c905f032dd\",\"to\":\"0x9d55b546f53e6561568de35292c382a07ff30180\",\"value\":\"0\"}",
-    transactionHash: "0xf2bcc5fedd4f0cd29458ce9e9cf2a4f64600bfcdcbcf92d13c56d8bfb1cd77f1",
-    blockHash: "0xb269558605d27f3a093cb3a402efe80a1ea4619a12c2c857c2065cc9439fd94b",
-    blockNumber: 20483211,
-    transactionIndex: "1",
-    logIndex: "0"
-  }) { eventName }
-
-  l2_2_2: create_Log(input: {
-    address: "0xef1b0ea9b30b5cb03df624d3f0487fcb9bd583ee",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0x4bd0b636914cda156f83dff4acc433044b071ad0df99f2d74578387d6f356473", "0x4c1864d0621cd977adf1d1938b8bd7a15101a69f83d58fba93304abbb786c234"],
-    data: "0x166e32a9f64146d8bbe3d2fd05849116cf25eccc8650560e897983571791484817630bba284d9a1",
-    transactionHash: "0xf2bcc5fedd4f0cd29458ce9e9cf2a4f64600bfcdcbcf92d13c56d8bfb1cd77f1",
-    blockHash: "0xb269558605d27f3a093cb3a402efe80a1ea4619a12c2c857c2065cc9439fd94b",
-    blockNumber: 20483211,
-    transactionIndex: "1",
-    logIndex: "1",
-    removed: "false"
-  }) { address }
-
-  e2_2_2: create_Event(input: {
-    contractAddress: "0xef1b0ea9b30b5cb03df624d3f0487fcb9bd583ee",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0xb048e4875032cc26d5d89c9d23b486c905f032dd\",\"to\":\"0x9d55b546f53e6561568de35292c382a07ff30180\",\"value\":\"0\"}",
-    transactionHash: "0xf2bcc5fedd4f0cd29458ce9e9cf2a4f64600bfcdcbcf92d13c56d8bfb1cd77f1",
-    blockHash: "0xb269558605d27f3a093cb3a402efe80a1ea4619a12c2c857c2065cc9439fd94b",
-    blockNumber: 20483211,
-    transactionIndex: "1",
-    logIndex: "1"
-  }) { eventName }
-
-  l2_2_3: create_Log(input: {
-    address: "0x0b785803c86e7a86c4e7db4f2f5e556f590955c6",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0x42d7ec3403cc030147284003a264fe59af4718301393d40707dc4b97c3f53739", "0xb2a3b2145da5d499b38fb82044a4cef23d842a45cbafdfda47cdff7c2d727b06"],
-    data: "0xbf431bb49e4d7671434c0db132f504b42720d45f49fdae093411550cde897d582c",
-    transactionHash: "0xf2bcc5fedd4f0cd29458ce9e9cf2a4f64600bfcdcbcf92d13c56d8bfb1cd77f1",
-    blockHash: "0xb269558605d27f3a093cb3a402efe80a1ea4619a12c2c857c2065cc9439fd94b",
-    blockNumber: 20483211,
-    transactionIndex: "1",
-    logIndex: "2",
-    removed: "false"
-  }) { address }
-
-  e2_2_3: create_Event(input: {
-    contractAddress: "0x0b785803c86e7a86c4e7db4f2f5e556f590955c6",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0xb048e4875032cc26d5d89c9d23b486c905f032dd\",\"to\":\"0x9d55b546f53e6561568de35292c382a07ff30180\",\"value\":\"0\"}",
-    transactionHash: "0xf2bcc5fedd4f0cd29458ce9e9cf2a4f64600bfcdcbcf92d13c56d8bfb1cd77f1",
-    blockHash: "0xb269558605d27f3a093cb3a402efe80a1ea4619a12c2c857c2065cc9439fd94b",
-    blockNumber: 20483211,
-    transactionIndex: "1",
-    logIndex: "2"
-  }) { eventName }
-
-  t2_3: create_Transaction(input: {
-    hash: "0x46c17c52efacc51bd68332ba0795326096617821f11a290b9c6acb43ad340cf1",
-    blockHash: "0xb269558605d27f3a093cb3a402efe80a1ea4619a12c2c857c2065cc9439fd94b",
-    blockNumber: 20483211,
-    from: "0x954e227645ae4a9bd1c7624f30492f3ea59528bb",
-    to: "0x225e8f8e43f1b9cd4ebab2de81170439c5c27ce2",
-    value: "1000",
-    gasUsed: "143127",
-    gasPrice: "30000000000",
-    inputData: "0x3253cd6ca2aaf6f38e14f46a1c1bdf6160d8852428c29ed68512da956bd",
-    nonce: "123",
-    transactionIndex: "2",
-    r: "0xf5dbc0624aa04e4fa3d80e4e3166d5c6b660bb0993feddbbda35edb55dc9d932",
-    s: "0x320d3f3e19d67ec36f3bedc0b79889d70d1004baa5d7c6c1d4c5ca5d7343c85a",
-    v: "0x1b"
-  }) { hash }
-
-  t2_4: create_Transaction(input: {
-    hash: "0x20d0402c04eb577967c81824033e33498522fb6c3f0d2f26dcae5590513abf05",
-    blockHash: "0xb269558605d27f3a093cb3a402efe80a1ea4619a12c2c857c2065cc9439fd94b",
-    blockNumber: 20483211,
-    from: "0x8360046b360a472488f62b9efdc68568c3956fde",
-    to: "0xd8a3cd6bb2e518d9bc035ad5b726bb4a30a0a6ea",
-    value: "100",
-    gasUsed: "168230",
-    gasPrice: "10000000000",
-    inputData: "0x966382ddaa661ff18d33e5ac70900e94c11a02f3d98abc2af",
-    nonce: "156",
-    transactionIndex: "3",
-    r: "0x1c9ef3b3071043ad7526b018131928ac854e34a4de37ff8af72892b7622f1606",
-    s: "0xec6f3a6a9e4347bce6c628d5934e3370e580feb832bd64cda1e8b31cd696c58f",
-    v: "0x1c"
-  }) { hash }
-
-  t2_5: create_Transaction(input: {
-    hash: "0x1737311872387ccc378f656b99035f975a255ae40fda058250bf0f7f31097543",
-    blockHash: "0xb269558605d27f3a093cb3a402efe80a1ea4619a12c2c857c2065cc9439fd94b",
-    blockNumber: 20483211,
-    from: "0x39aefb8f8be0b9af3804d74bf07db626c38e58ba",
-    to: "0xcd8961a3deb930f4e4959f9290e16931f90db018",
-    value: "10",
-    gasUsed: "112807",
-    gasPrice: "17000000000",
-    inputData: "0x42846d2971fb7cdc38995da4684d69929e5cd34eabebdedde00d2497b491c4c0",
-    nonce: "118",
-    transactionIndex: "4",
-    r: "0xe12183a39fa13164f474990f6320433763f0ec139cf578e3d4054756ff993fb8",
-    s: "0xcc3edd409e3c091e1b4ee805b6bc254bae489c2fcf584abc2105733ffa7735cd",
-    v: "0x1b"
-  }) { hash }
-
-  t2_6: create_Transaction(input: {
-    hash: "0x8312eb05a3ec4668fe9765d62036140bd2a5f66fbb42edc224933f71a0798cb2",
-    blockHash: "0xb269558605d27f3a093cb3a402efe80a1ea4619a12c2c857c2065cc9439fd94b",
-    blockNumber: 20483211,
-    from: "0x59279c13f801ad86a146a17f21b2d2f48131f7bd",
-    to: "0xf970106c0f1cc4dd43e3bb6ad177207d1071214e",
-    value: "10",
-    gasUsed: "95080",
-    gasPrice: "8000000000",
-    inputData: "0xb794cf32286fb7e9b978a31bdf82647963b417ee",
-    nonce: "29",
-    transactionIndex: "5",
-    r: "0x0f188c9218cf0cce176c5d191b0a860add13c9ed85ce74088279ac18b88039a8",
-    s: "0x5ee0e0e1bf6d128a2e5888f475417315ea171880b17b32e3276abd2d940abadb",
-    v: "0x1c"
-  }) { hash }
-
-  l2_6_1: create_Log(input: {
-    address: "0x05b194036ab6c14c227d31fea8697a7b7ea37edb",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0xb2bf7ed747d489aa32dd4f65e053d8f341d0524cdb4c793aa312beded9f45240", "0xbecae58379fa1d9aca5416d8a3b95398fe759837843650160f0b69de4e933edf"],
-    data: "0x2483b272a5a8e2a1d3a61074c768f4f5f946260d2f651d8c7bf5979ffcbf93739dea7d35ea3bc4ffd70986d1a8adcedc8",
-    transactionHash: "0x8312eb05a3ec4668fe9765d62036140bd2a5f66fbb42edc224933f71a0798cb2",
-    blockHash: "0xb269558605d27f3a093cb3a402efe80a1ea4619a12c2c857c2065cc9439fd94b",
-    blockNumber: 20483211,
-    transactionIndex: "5",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e2_6_1: create_Event(input: {
-    contractAddress: "0x05b194036ab6c14c227d31fea8697a7b7ea37edb",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0x59279c13f801ad86a146a17f21b2d2f48131f7bd\",\"to\":\"0xf970106c0f1cc4dd43e3bb6ad177207d1071214e\",\"value\":\"10\"}",
-    transactionHash: "0x8312eb05a3ec4668fe9765d62036140bd2a5f66fbb42edc224933f71a0798cb2",
-    blockHash: "0xb269558605d27f3a093cb3a402efe80a1ea4619a12c2c857c2065cc9439fd94b",
-    blockNumber: 20483211,
-    transactionIndex: "5",
-    logIndex: "0"
-  }) { eventName }
-
-  t2_7: create_Transaction(input: {
-    hash: "0x18f7a19ed7563a400c2ab216b65c795bad670103cf1599077183cc48222d0043",
-    blockHash: "0xb269558605d27f3a093cb3a402efe80a1ea4619a12c2c857c2065cc9439fd94b",
-    blockNumber: 20483211,
-    from: "0xc69ad098e638fc9d27d8f97c0fcb3e70c7ebf39a",
-    to: "0x42356f724cf71f8d9a41ad086ffa7aef23d2c405",
-    value: "1",
-    gasUsed: "64567",
-    gasPrice: "15000000000",
-    inputData: "0x31df5f4dc093d98ab5496b8fe6a45f0ad54f209663ea31e52b7b0689",
-    nonce: "109",
-    transactionIndex: "6",
-    r: "0x9bc86243685834ca8f650762445f0a214edfa937cccfb9a26584def83db50beb",
-    s: "0xd66cb506eb609a3b80818fc18810fef5f31b04542d31e1a3860aa5b0cd126482",
-    v: "0x1b"
-  }) { hash }
-
-  l2_7_1: create_Log(input: {
-    address: "0x186d5098b3ae2e232525a0506be2796491c9584a",
-    topics: ["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", "0x7686598e82fbbbe51c46db96a82686e8135f4eabc1a3b05dfaa35b95e50eedcf", "0x78bafc9173dd8c0559644a1294bec5e0465992576d274b0f5b3fc6fce73c4a4c"],
-    data: "0x9dc2bf0757bba0c274f6169d2ac5d499cf18d55c3e2b3c05a4ce0fcd19d83ebfab35dc240a86ed1e913feb1b8da90859bd0ea913b",
-    transactionHash: "0x18f7a19ed7563a400c2ab216b65c795bad670103cf1599077183cc48222d0043",
-    blockHash: "0xb269558605d27f3a093cb3a402efe80a1ea4619a12c2c857c2065cc9439fd94b",
-    blockNumber: 20483211,
-    transactionIndex: "6",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e2_7_1: create_Event(input: {
-    contractAddress: "0x186d5098b3ae2e232525a0506be2796491c9584a",
-    eventName: "Approval",
-    parameters: "{\"owner\":\"0xc69ad098e638fc9d27d8f97c0fcb3e70c7ebf39a\",\"spender\":\"0x42356f724cf71f8d9a41ad086ffa7aef23d2c405\",\"value\":\"1\"}",
-    transactionHash: "0x18f7a19ed7563a400c2ab216b65c795bad670103cf1599077183cc48222d0043",
-    blockHash: "0xb269558605d27f3a093cb3a402efe80a1ea4619a12c2c857c2065cc9439fd94b",
-    blockNumber: 20483211,
-    transactionIndex: "6",
-    logIndex: "0"
-  }) { eventName }
-
-  l2_7_2: create_Log(input: {
-    address: "0x1c752344fd8be7e12ab143c2a9dc0582d368971b",
-    topics: ["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", "0x6d8581c5980d60d488ea3770a729edacf0aaabe4ef65c8c12fb26b99aee045bd", "0xd09f7c4c33c663955cdb6d8ab3ac7cfe9e55c90ae53cddd60742d0a75f2b0c65"],
-    data: "0xb75f6a49206ee7e75e3a57e201dfc2d830ef19c1bced334835bda47f683a2ef78a9eae88144907bb9959fe94449c87069408bcf5b4abcf5f5fc02a7967",
-    transactionHash: "0x18f7a19ed7563a400c2ab216b65c795bad670103cf1599077183cc48222d0043",
-    blockHash: "0xb269558605d27f3a093cb3a402efe80a1ea4619a12c2c857c2065cc9439fd94b",
-    blockNumber: 20483211,
-    transactionIndex: "6",
-    logIndex: "1",
-    removed: "false"
-  }) { address }
-
-  e2_7_2: create_Event(input: {
-    contractAddress: "0x1c752344fd8be7e12ab143c2a9dc0582d368971b",
-    eventName: "Approval",
-    parameters: "{\"owner\":\"0xc69ad098e638fc9d27d8f97c0fcb3e70c7ebf39a\",\"spender\":\"0x42356f724cf71f8d9a41ad086ffa7aef23d2c405\",\"value\":\"1\"}",
-    transactionHash: "0x18f7a19ed7563a400c2ab216b65c795bad670103cf1599077183cc48222d0043",
-    blockHash: "0xb269558605d27f3a093cb3a402efe80a1ea4619a12c2c857c2065cc9439fd94b",
-    blockNumber: 20483211,
-    transactionIndex: "6",
-    logIndex: "1"
-  }) { eventName }
-
-  t2_8: create_Transaction(input: {
-    hash: "0x4836bfe076b1c3a2821e778577e5188262491677fe31a26f3e2f636f90d3e6e0",
-    blockHash: "0xb269558605d27f3a093cb3a402efe80a1ea4619a12c2c857c2065cc9439fd94b",
-    blockNumber: 20483211,
-    from: "0x8d8f5af9987a89e35f0aff552d93ea5637699af3",
-    to: "0x964a56c555afd878f9b49abae9dcd0c1db4e8066",
-    value: "500",
-    gasUsed: "98279",
-    gasPrice: "20000000000",
-    inputData: "0xadc",
-    nonce: "83",
-    transactionIndex: "7",
-    r: "0x66e83275aff1cf78c131a8be93f42ad44962e7a89042abe65ae7eba688043ddc",
-    s: "0xf11b0d1af9a222352e62d8ee4a25aed0c90c007ad487ae6b4646953014b2aa76",
-    v: "0x1b"
-  }) { hash }
-
-  l2_8_1: create_Log(input: {
-    address: "0x5d876b04e3c0e6c1eec66c3253563fbad662bf83",
-    topics: ["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", "0x00cdc3bb92d972cf08a14750444f1169bd5d5545b350f69cb8a00a0f14d1c553", "0x0b72d23fede409ff84ab3ff64744723c9377859ae84adb41c16504175ca0ffb6"],
-    data: "0xe6e8e38aa58afe3a82bd0437e3394b9ed25c64706b41b75b53574d681c9cdfea490289621d44f57c5dc67b2784c346e48a0393f7e93e42a81c8",
-    transactionHash: "0x4836bfe076b1c3a2821e778577e5188262491677fe31a26f3e2f636f90d3e6e0",
-    blockHash: "0xb269558605d27f3a093cb3a402efe80a1ea4619a12c2c857c2065cc9439fd94b",
-    blockNumber: 20483211,
-    transactionIndex: "7",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e2_8_1: create_Event(input: {
-    contractAddress: "0x5d876b04e3c0e6c1eec66c3253563fbad662bf83",
-    eventName: "Approval",
-    parameters: "{\"owner\":\"0x8d8f5af9987a89e35f0aff552d93ea5637699af3\",\"spender\":\"0x964a56c555afd878f9b49abae9dcd0c1db4e8066\",\"value\":\"500\"}",
-    transactionHash: "0x4836bfe076b1c3a2821e778577e5188262491677fe31a26f3e2f636f90d3e6e0",
-    blockHash: "0xb269558605d27f3a093cb3a402efe80a1ea4619a12c2c857c2065cc9439fd94b",
-    blockNumber: 20483211,
-    transactionIndex: "7",
-    logIndex: "0"
-  }) { eventName }
-
-  t2_9: create_Transaction(input: {
-    hash: "0x3ed5f9732b7fdd13888ad8b203f7f7d83fcc133337bdc1bee1cd0650a39d0e8b",
-    blockHash: "0xb269558605d27f3a093cb3a402efe80a1ea4619a12c2c857c2065cc9439fd94b",
-    blockNumber: 20483211,
-    from: "0xbb78e1ae856acb5f2ab7a932caf5c68fbaeb55a0",
-    to: "0x36995c2622c84abc4c392a7e17480f7777e64097",
-    value: "0",
-    gasUsed: "245796",
-    gasPrice: "60000000000",
-    inputData: "0xed6d5cc8b8dbb7ab24a743fa37b7e81eefd250e1bf42b2880fd4c6e99a7d4",
-    nonce: "196",
-    transactionIndex: "8",
-    r: "0xa01b322d567550f3a23ccdcf4a539b5d8f258c67b2ae38011b35000ac90b256f",
-    s: "0x56b34b5e54e013993b553f64aece32a7b47f6c1b1f32ac69a4e69dcdc2f0f3af",
-    v: "0x1c"
-  }) { hash }
-
-  l2_9_1: create_Log(input: {
-    address: "0xf9116295a1019c6b1d5b163e57a26f601c63907a",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0xc7bc14478d968d0ddc86f80c1e472335f25a58c999833c62f641ff3371c5227d", "0xbe4e166a104a85be61cc492756ae0e27954a132d05ab14370c01c37120fc9ce7"],
-    data: "0x8bef4eb7495c85b0d941ed7c4b6cddeeecebaac467666bedb96c4f3e9d166a5cd5e06c584c64dae74fa1322001a2ab64692baefa5993545d3d5f8734e314cf",
-    transactionHash: "0x3ed5f9732b7fdd13888ad8b203f7f7d83fcc133337bdc1bee1cd0650a39d0e8b",
-    blockHash: "0xb269558605d27f3a093cb3a402efe80a1ea4619a12c2c857c2065cc9439fd94b",
-    blockNumber: 20483211,
-    transactionIndex: "8",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e2_9_1: create_Event(input: {
-    contractAddress: "0xf9116295a1019c6b1d5b163e57a26f601c63907a",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0xbb78e1ae856acb5f2ab7a932caf5c68fbaeb55a0\",\"to\":\"0x36995c2622c84abc4c392a7e17480f7777e64097\",\"value\":\"0\"}",
-    transactionHash: "0x3ed5f9732b7fdd13888ad8b203f7f7d83fcc133337bdc1bee1cd0650a39d0e8b",
-    blockHash: "0xb269558605d27f3a093cb3a402efe80a1ea4619a12c2c857c2065cc9439fd94b",
-    blockNumber: 20483211,
-    transactionIndex: "8",
-    logIndex: "0"
-  }) { eventName }
-
-  t2_10: create_Transaction(input: {
-    hash: "0xcf50be5e0fba2b2549c436a92bf0d5b8680fa51798eda18e2a14009c6fcc18ca",
-    blockHash: "0xb269558605d27f3a093cb3a402efe80a1ea4619a12c2c857c2065cc9439fd94b",
-    blockNumber: 20483211,
-    from: "0xbdda4b86f982e2a3043725b2472200a24ea33146",
-    to: "0x25220d7612ca6f6f5f91e502568463265a75c9d9",
-    value: "100",
-    gasUsed: "132810",
-    gasPrice: "17000000000",
-    inputData: "0x70895212fb1d2e02ab28aebfbf9fa6751bdeeaceee44",
-    nonce: "188",
-    transactionIndex: "9",
-    r: "0xcd04ac4cb0d545630cf48a60fc59876ffdd5f1b32af947f6df095a9d349ab4bf",
-    s: "0x20ebd76a7af8aa64a777ff0a3c4a2fe82ec684b1f770abf48afa66391697cd09",
-    v: "0x1c"
-  }) { hash }
-
-  l2_10_1: create_Log(input: {
-    address: "0x4900d2be4ec5ea38e86e954a031afb4ac0dac5a1",
-    topics: ["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", "0xa114f22443572bba2da2fc1dc426e538771017f117744aacc09f0d216167f0b2", "0xb5c64098bc568a6a8c39e0ec6531c366969be178609065a6fcaec5ff97230010"],
-    data: "0x09ec531b66db28d0913948e630f50327e880f2462cc01fded501289f680867e01df719b2bef5bb4abd5cbeb94fdbd284abe",
-    transactionHash: "0xcf50be5e0fba2b2549c436a92bf0d5b8680fa51798eda18e2a14009c6fcc18ca",
-    blockHash: "0xb269558605d27f3a093cb3a402efe80a1ea4619a12c2c857c2065cc9439fd94b",
-    blockNumber: 20483211,
-    transactionIndex: "9",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e2_10_1: create_Event(input: {
-    contractAddress: "0x4900d2be4ec5ea38e86e954a031afb4ac0dac5a1",
-    eventName: "Approval",
-    parameters: "{\"owner\":\"0xbdda4b86f982e2a3043725b2472200a24ea33146\",\"spender\":\"0x25220d7612ca6f6f5f91e502568463265a75c9d9\",\"value\":\"100\"}",
-    transactionHash: "0xcf50be5e0fba2b2549c436a92bf0d5b8680fa51798eda18e2a14009c6fcc18ca",
-    blockHash: "0xb269558605d27f3a093cb3a402efe80a1ea4619a12c2c857c2065cc9439fd94b",
-    blockNumber: 20483211,
-    transactionIndex: "9",
-    logIndex: "0"
-  }) { eventName }
-
-  b3: create_Block(input: {
-    hash: "0xe51a4a546c2d3130857af3abcc7bd37e4603f4297c96360009365228e3dbc09a",
-    number: 20483212,
-    timestamp: "2023-07-01T12:04:00Z",
-    parentHash: "0xb269558605d27f3a093cb3a402efe80a1ea4619a12c2c857c2065cc9439fd94b",
-    difficulty: "1001900",
-    gasUsed: "18010640",
+  b3: add_Ethereum__Mainnet__Block(input: {
+    hash: "0x6a5c5976632399a8b59f3fa6ccb7aefb34af0e3c4480e7fa7fc0a3ef937c3dff",
+    number: 18500002,
+    timestamp: "2023-11-01T12:00:24Z",
+    parentHash: "0x5f4b4865521288f7a48ef2f95bba69ea239f9d2b3369d6f96eb9f2de826b2cee",
+    difficulty: "0",
+    gasUsed: "18000000",
     gasLimit: "30000000",
-    nonce: "0xd3040e25e8c183f5",
-    miner: "0xb69df1f1fab08fc3dbf0c1f2f82273eca7f1a9e6",
-    size: "1923",
-    stateRoot: "0x0528f337d77e55783079dce6732dee4cc086fdaa0fce6b42c5c66abc8797cf07",
-    sha3Uncles: "0xe9519ad3426ff70c5c1957af7e335440efbd0b3df18dd2228bfc74305256eb8f",
-    transactionsRoot: "0x25d3176494c0b1038094a7f66fff635c24442f257db78d1d1ac06bce74fd579f",
-    receiptsRoot: "0x2d0d2241b8c8ea9a9ffc4fa2fa288897aa76b96ad88d6496ba6e53976a5fb7cf",
-    extraData: "0x8ea48283cc0268fe8d681df3fdca3453b11283843d61103a89d7778b740a75c6"
+    nonce: "0x0000000000000000",
+    miner: "0x95222290DD7278Aa3Ddd389Cc1E1d165CC4BAfe5",
+    size: "1500",
+    stateRoot: "0x789abc123def456789abc123def456789abc123def456789abc123def456789a",
+    sha3Uncles: "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+    transactionsRoot: "0xfedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321",
+    receiptsRoot: "0x0987654321fedcba0987654321fedcba0987654321fedcba0987654321fedcba",
+    extraData: "0x"
+  }) { hash }
+}`
+
+const GQL_TRANSACTIONS = `mutation {
+  t1_1: add_Ethereum__Mainnet__Transaction(input: {
+    hash: "0xaa1c8b56e2f34d79e0b1a2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3",
+    blockHash: "0x4e3a3754410177e6937ef1f84bba68ea139e8d1a2258c5f85db9f1cd715a1bdd",
+    blockNumber: 18500000,
+    from: "0xDFd5293D8e347dFe59E90eFd55b2956a1343963d",
+    to: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    value: "0", gasUsed: "65000", gasPrice: "30000000000",
+    input: "0xa9059cbb00000000000000000000000028C6c06298d514Db089934071355E5743bf21d6000000000000000000000000000000000000000000000000000000000003d0900",
+    nonce: "100", transactionIndex: 0,
+    r: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+    s: "0xfedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321", v: "0x1c"
   }) { hash }
 
-  t3_1: create_Transaction(input: {
-    hash: "0x2e0cbbc0fded2d8b78b8f55761cb172521828e494d857d95272159fd57062238",
-    blockHash: "0xe51a4a546c2d3130857af3abcc7bd37e4603f4297c96360009365228e3dbc09a",
-    blockNumber: 20483212,
-    from: "0x53eb54570a5801c451f447b8e7e537512c409efc",
-    to: "0xcebc8d5f4162b93dcc9b0af606d4e49c7407e8fc",
-    value: "10000",
-    gasUsed: "207879",
-    gasPrice: "30000000000",
-    inputData: "0x6e4d17439b1becd29bf1f2ba6950348106b0ecaeba9b13e",
-    nonce: "194",
-    transactionIndex: "0",
-    r: "0xfd124cae84462c8c7119046d6d4d8602518f27e5f32eabf8aa48770df8a9fc19",
-    s: "0x834777e43bdcda9275f2a1dcd4df0ab397ffc6cd7975a5ac232204df2410f514",
-    v: "0x1c"
+  t1_2: add_Ethereum__Mainnet__Transaction(input: {
+    hash: "0xbb2d9c67f3e45a80f1c2b3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4",
+    blockHash: "0x4e3a3754410177e6937ef1f84bba68ea139e8d1a2258c5f85db9f1cd715a1bdd",
+    blockNumber: 18500000,
+    from: "0x28C6c06298d514Db089934071355E5743bf21d60",
+    to: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    value: "0", gasUsed: "52000", gasPrice: "28000000000",
+    input: "0xa9059cbb000000000000000000000000d8dA6BF26964aF9D7eEd9e03E53415D37aA96045000000000000000000000000000000000000000000000000000000174876e800",
+    nonce: "5012", transactionIndex: 1,
+    r: "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+    s: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef", v: "0x1b"
   }) { hash }
 
-  l3_1_1: create_Log(input: {
-    address: "0xb2159a3121065cf3892942e853f791ca5feb99cd",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0x9a67e44121343e4429aa7fdd396f1b5c6b2118c5fecae4ada5058d2fa4147f86", "0x5d10baba03f664a8c6d1e9e19a0d2fde7a7e89178c80717e7c0d128d091f6937"],
-    data: "0xa560d2a7f0348598d5d65b3992243072853ea3e3f82b2b5c6802254a56fb0acd3c656f27fecab611e60b0bad0ae24334ffa31a79d9131948c",
-    transactionHash: "0x2e0cbbc0fded2d8b78b8f55761cb172521828e494d857d95272159fd57062238",
-    blockHash: "0xe51a4a546c2d3130857af3abcc7bd37e4603f4297c96360009365228e3dbc09a",
-    blockNumber: 20483212,
-    transactionIndex: "0",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e3_1_1: create_Event(input: {
-    contractAddress: "0xb2159a3121065cf3892942e853f791ca5feb99cd",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0x53eb54570a5801c451f447b8e7e537512c409efc\",\"to\":\"0xcebc8d5f4162b93dcc9b0af606d4e49c7407e8fc\",\"value\":\"10000\"}",
-    transactionHash: "0x2e0cbbc0fded2d8b78b8f55761cb172521828e494d857d95272159fd57062238",
-    blockHash: "0xe51a4a546c2d3130857af3abcc7bd37e4603f4297c96360009365228e3dbc09a",
-    blockNumber: 20483212,
-    transactionIndex: "0",
-    logIndex: "0"
-  }) { eventName }
-
-  t3_2: create_Transaction(input: {
-    hash: "0x48ad2b2f99d009a5243b338aa356271892993c19d2a8142303f1fbc38572a553",
-    blockHash: "0xe51a4a546c2d3130857af3abcc7bd37e4603f4297c96360009365228e3dbc09a",
-    blockNumber: 20483212,
-    from: "0x0f6457d086f71d6c69b4cd9873d8f03c68453741",
-    to: "0x7712c46830630d3a6e443badc8e646cb67ff8d18",
-    value: "0",
-    gasUsed: "134585",
-    gasPrice: "30000000000",
-    inputData: "0x11e96d394985d0f2eb97",
-    nonce: "115",
-    transactionIndex: "1",
-    r: "0x68fc85f7e407fc7438b8389c02379875f040ada0f6539d886cb3cf67a1abf7af",
-    s: "0x7d02347d16ed23e4766b3180d38e62a732871f850f6da32780dbbe5030865571",
-    v: "0x1b"
+  t1_3: add_Ethereum__Mainnet__Transaction(input: {
+    hash: "0xcc3eab78a4f56b91a2d3c4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5",
+    blockHash: "0x4e3a3754410177e6937ef1f84bba68ea139e8d1a2258c5f85db9f1cd715a1bdd",
+    blockNumber: 18500000,
+    from: "0x47ac0Fb4F2D84898e4D9E7b4DaB3C24507a6D503",
+    to: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    value: "0", gasUsed: "48000", gasPrice: "32000000000",
+    input: "0x095ea7b3000000000000000000000000E592427A0AEce92De3Edee1F18E0157C05861564ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    nonce: "782", transactionIndex: 2,
+    r: "0x567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234",
+    s: "0xcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab", v: "0x1c"
   }) { hash }
 
-  l3_2_1: create_Log(input: {
-    address: "0x6649e1e74136b9d425fc05b15d325624d3d758ae",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0x6ed5e8a8606c9ce234173fc4157471272a288a451df64724e2d2ae58a0100002", "0xa5226f3eb104bac3998524f9f24591acf1de011087cba2b84cc37d487ab1b95c"],
-    data: "0x1f1d67deb05421813c830885ff76c62c87424c959d9507d4bd63982e1c9c5bb915c7b",
-    transactionHash: "0x48ad2b2f99d009a5243b338aa356271892993c19d2a8142303f1fbc38572a553",
-    blockHash: "0xe51a4a546c2d3130857af3abcc7bd37e4603f4297c96360009365228e3dbc09a",
-    blockNumber: 20483212,
-    transactionIndex: "1",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e3_2_1: create_Event(input: {
-    contractAddress: "0x6649e1e74136b9d425fc05b15d325624d3d758ae",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0x0f6457d086f71d6c69b4cd9873d8f03c68453741\",\"to\":\"0x7712c46830630d3a6e443badc8e646cb67ff8d18\",\"value\":\"0\"}",
-    transactionHash: "0x48ad2b2f99d009a5243b338aa356271892993c19d2a8142303f1fbc38572a553",
-    blockHash: "0xe51a4a546c2d3130857af3abcc7bd37e4603f4297c96360009365228e3dbc09a",
-    blockNumber: 20483212,
-    transactionIndex: "1",
-    logIndex: "0"
-  }) { eventName }
-
-  t3_3: create_Transaction(input: {
-    hash: "0xa59602fc9d89073b758a4e1a19197666b68a3c74323ee316726f64ca71d122fa",
-    blockHash: "0xe51a4a546c2d3130857af3abcc7bd37e4603f4297c96360009365228e3dbc09a",
-    blockNumber: 20483212,
-    from: "0xc3ed0056003ad3407caff893d06cbb4129239397",
-    to: "0x7cfa04d6556427e8aad228194d1b0a7fcdd1334d",
-    value: "0",
-    gasUsed: "32051",
-    gasPrice: "15000000000",
-    inputData: "0x6bcc20c",
-    nonce: "39",
-    transactionIndex: "2",
-    r: "0xe2a63568ab1d5d3ffd468913790e6a97f4d167b313be01b29950e85cdc9e294b",
-    s: "0xc74a390965635794dc1d0f4c3ed0e56977ab74090bd34da04cb4d82ccbd260fd",
-    v: "0x1b"
+  t1_4: add_Ethereum__Mainnet__Transaction(input: {
+    hash: "0xdd4fbc89b5a67ca2b3e4d5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6",
+    blockHash: "0x4e3a3754410177e6937ef1f84bba68ea139e8d1a2258c5f85db9f1cd715a1bdd",
+    blockNumber: 18500000,
+    from: "0x56Eddb7aa87536c09CCc2793473599fD21A8b17F",
+    to: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    value: "0", gasUsed: "65000", gasPrice: "35000000000",
+    input: "0xa9059cbb000000000000000000000000Dac17F958D2ee523a2206206994597C13D831ec70000000000000000000000000000000000000000000000000000000005f5e100",
+    nonce: "341", transactionIndex: 3,
+    r: "0x890abcdef1234567890abcdef1234567890abcdef1234567890abcdef12345678",
+    s: "0xef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef", v: "0x1b"
   }) { hash }
 
-  l3_3_1: create_Log(input: {
-    address: "0x46aa3868c4798105f700dcc213c6226a012c1829",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0xa1ed56ed41b7880fee9c51e4cd44b02ffc15280c82666e724ab56bc3e2e06532", "0x50c37d7a4efbc366e299815a14c913d8917e683cf34ef552052f5368d5afe7d7"],
-    data: "0x35ad0a7e0fdc3ef1cf7c40b0c42557ba52cb0ae38c42524ace187d90541a17d8949a229bee1e2b57cecf650e8c22eff",
-    transactionHash: "0xa59602fc9d89073b758a4e1a19197666b68a3c74323ee316726f64ca71d122fa",
-    blockHash: "0xe51a4a546c2d3130857af3abcc7bd37e4603f4297c96360009365228e3dbc09a",
-    blockNumber: 20483212,
-    transactionIndex: "2",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e3_3_1: create_Event(input: {
-    contractAddress: "0x46aa3868c4798105f700dcc213c6226a012c1829",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0xc3ed0056003ad3407caff893d06cbb4129239397\",\"to\":\"0x7cfa04d6556427e8aad228194d1b0a7fcdd1334d\",\"value\":\"0\"}",
-    transactionHash: "0xa59602fc9d89073b758a4e1a19197666b68a3c74323ee316726f64ca71d122fa",
-    blockHash: "0xe51a4a546c2d3130857af3abcc7bd37e4603f4297c96360009365228e3dbc09a",
-    blockNumber: 20483212,
-    transactionIndex: "2",
-    logIndex: "0"
-  }) { eventName }
-
-  l3_3_2: create_Log(input: {
-    address: "0xc4df44a6f1a0c57b180bccae103585ab885cec64",
-    topics: ["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", "0x95748c763ac582a5af5ac55c77ab373cbb0f8ca0af987069323ff516a7812b6c", "0x92a9e3aa6365b6df37dea10843921b5ec3f14f08b47bc54add1adee8954faa8a"],
-    data: "0xba954932da0401149b772743aa260aaf16d53999ccf4f7dee9d404b5b9626534624640921c027d8f56eb05fc2e55bfea8b8f4c41a42ec73c15e3f5",
-    transactionHash: "0xa59602fc9d89073b758a4e1a19197666b68a3c74323ee316726f64ca71d122fa",
-    blockHash: "0xe51a4a546c2d3130857af3abcc7bd37e4603f4297c96360009365228e3dbc09a",
-    blockNumber: 20483212,
-    transactionIndex: "2",
-    logIndex: "1",
-    removed: "false"
-  }) { address }
-
-  e3_3_2: create_Event(input: {
-    contractAddress: "0xc4df44a6f1a0c57b180bccae103585ab885cec64",
-    eventName: "Approval",
-    parameters: "{\"owner\":\"0xc3ed0056003ad3407caff893d06cbb4129239397\",\"spender\":\"0x7cfa04d6556427e8aad228194d1b0a7fcdd1334d\",\"value\":\"0\"}",
-    transactionHash: "0xa59602fc9d89073b758a4e1a19197666b68a3c74323ee316726f64ca71d122fa",
-    blockHash: "0xe51a4a546c2d3130857af3abcc7bd37e4603f4297c96360009365228e3dbc09a",
-    blockNumber: 20483212,
-    transactionIndex: "2",
-    logIndex: "1"
-  }) { eventName }
-
-  l3_3_3: create_Log(input: {
-    address: "0x2e66e650a5546d53da297475ab76a98d3fef75c9",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0x0a88f35ee055e251a7ef36fa4744034bc165118feeb6bb57c1160897c2a3e2b5", "0x62045b0296f86160df26f234c1443653ede413233cc345131e4ae766196dca60"],
-    data: "0xe934953290c4a0a449c406bbc206b4f037e3486dbabc946082404f1d3b5f7f8151e2dd0d74493aa8507917",
-    transactionHash: "0xa59602fc9d89073b758a4e1a19197666b68a3c74323ee316726f64ca71d122fa",
-    blockHash: "0xe51a4a546c2d3130857af3abcc7bd37e4603f4297c96360009365228e3dbc09a",
-    blockNumber: 20483212,
-    transactionIndex: "2",
-    logIndex: "2",
-    removed: "false"
-  }) { address }
-
-  e3_3_3: create_Event(input: {
-    contractAddress: "0x2e66e650a5546d53da297475ab76a98d3fef75c9",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0xc3ed0056003ad3407caff893d06cbb4129239397\",\"to\":\"0x7cfa04d6556427e8aad228194d1b0a7fcdd1334d\",\"value\":\"0\"}",
-    transactionHash: "0xa59602fc9d89073b758a4e1a19197666b68a3c74323ee316726f64ca71d122fa",
-    blockHash: "0xe51a4a546c2d3130857af3abcc7bd37e4603f4297c96360009365228e3dbc09a",
-    blockNumber: 20483212,
-    transactionIndex: "2",
-    logIndex: "2"
-  }) { eventName }
-
-  t3_4: create_Transaction(input: {
-    hash: "0x130bcfebd92bebb9d578f348ed031133160d73ec82f5d103be3403a1e261de37",
-    blockHash: "0xe51a4a546c2d3130857af3abcc7bd37e4603f4297c96360009365228e3dbc09a",
-    blockNumber: 20483212,
-    from: "0x1e7a219b8f96c53600d5bbedd8f0630a66c5e8dc",
-    to: "0xd42b274f0118cdd39a0231efe381087280a72a51",
-    value: "500",
-    gasUsed: "181054",
-    gasPrice: "60000000000",
-    inputData: "0x19fcf726ee3dc93dc346f91ff8775ad5693e0285d406e1e532d1508327be432e",
-    nonce: "5",
-    transactionIndex: "3",
-    r: "0x902c89453eb7ebe051081dfaf256c29c225f85d4ecf181b7382d3bd1f75f97ac",
-    s: "0xb3ec591d9cc78d08e942e04a3c45b7d84078c71d48cf4e2d02292637b56d376f",
-    v: "0x1c"
+  t1_5: add_Ethereum__Mainnet__Transaction(input: {
+    hash: "0xee5acd9ac6b78db3c4f5e6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7",
+    blockHash: "0x4e3a3754410177e6937ef1f84bba68ea139e8d1a2258c5f85db9f1cd715a1bdd",
+    blockNumber: 18500000,
+    from: "0x21a31Ee1afC51d94C2eFcCAa2092aD1028285549",
+    to: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    value: "0", gasUsed: "65000", gasPrice: "29000000000",
+    input: "0xa9059cbb000000000000000000000000BE0eB53F46cd790Cd13851d5EFf43D12404d33E80000000000000000000000000000000000000000000000000000001caab5c3b3",
+    nonce: "456", transactionIndex: 4,
+    r: "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+    s: "0x567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234", v: "0x1c"
   }) { hash }
 
-  t3_5: create_Transaction(input: {
-    hash: "0xa5718a3ca05b89f4833da16980dc2ff24810ce4382e8d37a5cc8d7ce9c92aa8a",
-    blockHash: "0xe51a4a546c2d3130857af3abcc7bd37e4603f4297c96360009365228e3dbc09a",
-    blockNumber: 20483212,
-    from: "0x133451fb7c1b32f2d17c6da7d438ab1cf0109498",
-    to: "0x519cc8ddfd1ad8509adbfea0e9a760d47b8cc45d",
-    value: "1000",
-    gasUsed: "204657",
-    gasPrice: "17000000000",
-    inputData: "0x3cab71",
-    nonce: "2",
-    transactionIndex: "4",
-    r: "0xd5535495edff9c4a2c0325832b8c1003fcff4625be08e4d85d24351687fa7dbc",
-    s: "0x1eb5b859437a8b811d89b9ea4623464e9f2eec6795f506c52fb012c718a61c7a",
-    v: "0x1b"
+  t1_6: add_Ethereum__Mainnet__Transaction(input: {
+    hash: "0xab01usdt1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d",
+    blockHash: "0x4e3a3754410177e6937ef1f84bba68ea139e8d1a2258c5f85db9f1cd715a1bdd",
+    blockNumber: 18500000,
+    from: "0xDFd5293D8e347dFe59E90eFd55b2956a1343963d",
+    to: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+    value: "0", gasUsed: "63000", gasPrice: "30000000000",
+    input: "0xa9059cbb00000000000000000000000028C6c06298d514Db089934071355E5743bf21d600000000000000000000000000000000000000000000000000000000005f5e100",
+    nonce: "101", transactionIndex: 5,
+    r: "0xaaaa567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+    s: "0xbbbbba0987654321fedcba0987654321fedcba0987654321fedcba0987654321", v: "0x1c"
   }) { hash }
 
-  l3_5_1: create_Log(input: {
-    address: "0x7a790132cef92db5888b88d16b2f6e30a734e8cd",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0x19af4f38e48c712c858467e577343f0c56516543130575002cedc310fc30296b", "0xc29179a721f8d46a9da31060ec50b8ace2a01ddcd8220cb922790ea3c8f10b6d"],
-    data: "0x694cc5ce07d3ff2b0bd5be2ec074024dbe5c0920b42ebaa3efe924f9c523482c4d8554fa2e18b843b9bf1ad4044bf0012c7ad81e5648f55a8012f",
-    transactionHash: "0xa5718a3ca05b89f4833da16980dc2ff24810ce4382e8d37a5cc8d7ce9c92aa8a",
-    blockHash: "0xe51a4a546c2d3130857af3abcc7bd37e4603f4297c96360009365228e3dbc09a",
-    blockNumber: 20483212,
-    transactionIndex: "4",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e3_5_1: create_Event(input: {
-    contractAddress: "0x7a790132cef92db5888b88d16b2f6e30a734e8cd",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0x133451fb7c1b32f2d17c6da7d438ab1cf0109498\",\"to\":\"0x519cc8ddfd1ad8509adbfea0e9a760d47b8cc45d\",\"value\":\"1000\"}",
-    transactionHash: "0xa5718a3ca05b89f4833da16980dc2ff24810ce4382e8d37a5cc8d7ce9c92aa8a",
-    blockHash: "0xe51a4a546c2d3130857af3abcc7bd37e4603f4297c96360009365228e3dbc09a",
-    blockNumber: 20483212,
-    transactionIndex: "4",
-    logIndex: "0"
-  }) { eventName }
-
-  t3_6: create_Transaction(input: {
-    hash: "0x558e724d2cb0f21b123b05e32a5d21b7e14611e2da00f829a974ed6db488f3d2",
-    blockHash: "0xe51a4a546c2d3130857af3abcc7bd37e4603f4297c96360009365228e3dbc09a",
-    blockNumber: 20483212,
-    from: "0x4f6926218a14bc752e96be87a4d1c8d1de678969",
-    to: "0x5a7c9c41aa1ee81cbeab2bc56501aa31f9037323",
-    value: "10000",
-    gasUsed: "225186",
-    gasPrice: "45000000000",
-    inputData: "0x304a9ec1550cb7a8250245eab105d12a3a65b8ea1e91f3e64",
-    nonce: "118",
-    transactionIndex: "5",
-    r: "0x1bb07210c96906308b416d1922937a5bb7ba41bc211df00cd12cef817f846699",
-    s: "0xb700cfec5aa065b02f6ca84c593e85154779a32011d1b70d870432cce7409aea",
-    v: "0x1c"
+  t1_7: add_Ethereum__Mainnet__Transaction(input: {
+    hash: "0xcd02weth2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e",
+    blockHash: "0x4e3a3754410177e6937ef1f84bba68ea139e8d1a2258c5f85db9f1cd715a1bdd",
+    blockNumber: 18500000,
+    from: "0x28C6c06298d514Db089934071355E5743bf21d60",
+    to: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+    value: "1000000000000000000", gasUsed: "45000", gasPrice: "30000000000",
+    input: "0xd0e30db0",
+    nonce: "5013", transactionIndex: 6,
+    r: "0xcccc567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+    s: "0xddddba0987654321fedcba0987654321fedcba0987654321fedcba0987654321", v: "0x1b"
   }) { hash }
 
-  l3_6_1: create_Log(input: {
-    address: "0x525d95c177d504ebb528ee040e32b57056d5352b",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0xf0b3d33d6ba2aef53c11a7f62c4f58a91345f501569474418288f86432db6040", "0x416184744efb437b6142da1d8c601b7eeebc3742052d2f9c156308782cc54263"],
-    data: "0xf01bcbdce1c7c42cbb199891edc6967db09c5e645c4d329486d4aa8431f3d4792c876a749e5b1b777861722bfc0b8bec8faec8a6b7dbf8ccc2d68",
-    transactionHash: "0x558e724d2cb0f21b123b05e32a5d21b7e14611e2da00f829a974ed6db488f3d2",
-    blockHash: "0xe51a4a546c2d3130857af3abcc7bd37e4603f4297c96360009365228e3dbc09a",
-    blockNumber: 20483212,
-    transactionIndex: "5",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e3_6_1: create_Event(input: {
-    contractAddress: "0x525d95c177d504ebb528ee040e32b57056d5352b",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0x4f6926218a14bc752e96be87a4d1c8d1de678969\",\"to\":\"0x5a7c9c41aa1ee81cbeab2bc56501aa31f9037323\",\"value\":\"10000\"}",
-    transactionHash: "0x558e724d2cb0f21b123b05e32a5d21b7e14611e2da00f829a974ed6db488f3d2",
-    blockHash: "0xe51a4a546c2d3130857af3abcc7bd37e4603f4297c96360009365228e3dbc09a",
-    blockNumber: 20483212,
-    transactionIndex: "5",
-    logIndex: "0"
-  }) { eventName }
-
-  t3_7: create_Transaction(input: {
-    hash: "0x425a9b00a92a5c4abcc9e5370e847b385c3918675d39a961ed7e73003fb5432b",
-    blockHash: "0xe51a4a546c2d3130857af3abcc7bd37e4603f4297c96360009365228e3dbc09a",
-    blockNumber: 20483212,
-    from: "0xe28a56b85de88f13f650da47eee4dcad66e03811",
-    to: "0xb4e20ba1104f54295ae63d09736c2f51636cbb4c",
-    value: "10",
-    gasUsed: "209965",
-    gasPrice: "8000000000",
-    inputData: "0xf7b4bb67454e76509bf7b74",
-    nonce: "58",
-    transactionIndex: "6",
-    r: "0xdd2b1fc21e15cf356c130f34c3b752fd88cf6ae8446644503984b455bc1c5a6b",
-    s: "0x1c7f72318cf8370fa793a4027c5c19c7fbc2a8f1ba8252b2d822aad802c6aefb",
-    v: "0x1b"
+  t2_1: add_Ethereum__Mainnet__Transaction(input: {
+    hash: "0xff6bde0ab7c89ec4d5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8",
+    blockHash: "0x5f4b4865521288f7a48ef2f95bba69ea239f9d2b3369d6f96eb9f2de826b2cee",
+    blockNumber: 18500001,
+    from: "0xBE0eB53F46cd790Cd13851d5EFf43D12404d33E8",
+    to: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    value: "0", gasUsed: "65000", gasPrice: "31000000000",
+    input: "0xa9059cbb0000000000000000000000005041ed759Dd4aFc3a72b8192C143F72f4724081A00000000000000000000000000000000000000000000000000000002540be400",
+    nonce: "9001", transactionIndex: 0,
+    r: "0xdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcd",
+    s: "0x90abcdef1234567890abcdef1234567890abcdef1234567890abcdef12345678", v: "0x1c"
   }) { hash }
 
-  t3_8: create_Transaction(input: {
-    hash: "0xf04085d502f34249267dceec1f625dff7254ec0eafdb769632ca960a57341532",
-    blockHash: "0xe51a4a546c2d3130857af3abcc7bd37e4603f4297c96360009365228e3dbc09a",
-    blockNumber: 20483212,
-    from: "0xb0bfc89e9f0104dec99dfc9ee92d6cbd18a10d7b",
-    to: "0xa7f61c8d5ee23b4c7a61be05bb355ed6d972a9ac",
-    value: "1000",
-    gasUsed: "94844",
-    gasPrice: "25000000000",
-    inputData: "0x79a89798293c7788e978d805471ad4f6837530e4153f1fa9b69dbaf",
-    nonce: "149",
-    transactionIndex: "7",
-    r: "0x44170198d9c247104b3436eacbc6aaf0d2628b968acc7227b16956d541769e95",
-    s: "0x8d63097edc01a48c142fe92e86196a147b1558dca5ea5664470404ac36607076",
-    v: "0x1c"
+  t2_2: add_Ethereum__Mainnet__Transaction(input: {
+    hash: "0x007cef1bc8d9afd5e6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9",
+    blockHash: "0x5f4b4865521288f7a48ef2f95bba69ea239f9d2b3369d6f96eb9f2de826b2cee",
+    blockNumber: 18500001,
+    from: "0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD",
+    to: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    value: "0", gasUsed: "52000", gasPrice: "33000000000",
+    input: "0xa9059cbb000000000000000000000000F977814e90dA44bFA03b6295A0616a897441aceC000000000000000000000000000000000000000000000000000000003b9aca00",
+    nonce: "221", transactionIndex: 1,
+    r: "0x4567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234",
+    s: "0xbcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab", v: "0x1b"
   }) { hash }
 
-  l3_8_1: create_Log(input: {
-    address: "0xee23deb0ed4fba7158b612578f570684149e202e",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0x5491b1ed8e3ffa8d3581cb7e4f4a254a1acc9847f76e25342213e17bd12e1f91", "0x74b38b5a3f3554fc877e550b9443c5ca8c66066999e09fa08e050bcb2a6ef85c"],
-    data: "0x65ad785effa55b40d2cb2440b54932ad614aac7d7e4d5951dc2a80a36637118752254352b93b4ddfc9033a81c99401c5fef7aacc9c93d469534d45",
-    transactionHash: "0xf04085d502f34249267dceec1f625dff7254ec0eafdb769632ca960a57341532",
-    blockHash: "0xe51a4a546c2d3130857af3abcc7bd37e4603f4297c96360009365228e3dbc09a",
-    blockNumber: 20483212,
-    transactionIndex: "7",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e3_8_1: create_Event(input: {
-    contractAddress: "0xee23deb0ed4fba7158b612578f570684149e202e",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0xb0bfc89e9f0104dec99dfc9ee92d6cbd18a10d7b\",\"to\":\"0xa7f61c8d5ee23b4c7a61be05bb355ed6d972a9ac\",\"value\":\"1000\"}",
-    transactionHash: "0xf04085d502f34249267dceec1f625dff7254ec0eafdb769632ca960a57341532",
-    blockHash: "0xe51a4a546c2d3130857af3abcc7bd37e4603f4297c96360009365228e3dbc09a",
-    blockNumber: 20483212,
-    transactionIndex: "7",
-    logIndex: "0"
-  }) { eventName }
-
-  l3_8_2: create_Log(input: {
-    address: "0x2650921958639f32fe4d83563017ddd05010b65a",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0xc630a1a58770b5d511ecd5ed7756c66fd2a3c5ce37d930264567437b5e2fa0cf", "0xfc31db5038724eed3e3bd79bf504ccbcc5b34ae695aa78d0e940e8f4dd92ecf0"],
-    data: "0xe9f8b9c82693de79ea6c3c9089a05c0a5315c4e1cc910588b37061af97f83bd7",
-    transactionHash: "0xf04085d502f34249267dceec1f625dff7254ec0eafdb769632ca960a57341532",
-    blockHash: "0xe51a4a546c2d3130857af3abcc7bd37e4603f4297c96360009365228e3dbc09a",
-    blockNumber: 20483212,
-    transactionIndex: "7",
-    logIndex: "1",
-    removed: "false"
-  }) { address }
-
-  e3_8_2: create_Event(input: {
-    contractAddress: "0x2650921958639f32fe4d83563017ddd05010b65a",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0xb0bfc89e9f0104dec99dfc9ee92d6cbd18a10d7b\",\"to\":\"0xa7f61c8d5ee23b4c7a61be05bb355ed6d972a9ac\",\"value\":\"1000\"}",
-    transactionHash: "0xf04085d502f34249267dceec1f625dff7254ec0eafdb769632ca960a57341532",
-    blockHash: "0xe51a4a546c2d3130857af3abcc7bd37e4603f4297c96360009365228e3dbc09a",
-    blockNumber: 20483212,
-    transactionIndex: "7",
-    logIndex: "1"
-  }) { eventName }
-
-  t3_9: create_Transaction(input: {
-    hash: "0x04eb01061bcc3b60bc9386e9de1f03f5d1036db317899841cf8adcb591c443ab",
-    blockHash: "0xe51a4a546c2d3130857af3abcc7bd37e4603f4297c96360009365228e3dbc09a",
-    blockNumber: 20483212,
-    from: "0xdf4ad55530a769e08f9fc99ab7da5377a0f249ab",
-    to: "0x635107c4522f74ef5d87baaa5595b4a3c3afb2e2",
-    value: "0",
-    gasUsed: "109077",
-    gasPrice: "8000000000",
-    inputData: "0xb928ee",
-    nonce: "78",
-    transactionIndex: "8",
-    r: "0x8f7b6b49e93e3b9e68961a7f07636d22675d1f52b5ff609d5a2a53e9da6a7f13",
-    s: "0x3bdf698cf2fec5c2976c48cd8a10131af707a532d9959c89ebe5bfab431542ee",
-    v: "0x1b"
+  t2_3: add_Ethereum__Mainnet__Transaction(input: {
+    hash: "0x118def2cd9eabae6f7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9fa",
+    blockHash: "0x5f4b4865521288f7a48ef2f95bba69ea239f9d2b3369d6f96eb9f2de826b2cee",
+    blockNumber: 18500001,
+    from: "0xF977814e90dA44bFA03b6295A0616a897441aceC",
+    to: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    value: "0", gasUsed: "48000", gasPrice: "30000000000",
+    input: "0x095ea7b300000000000000000000000068b3465833fb72A70ecDF485E0e4C7bD8665Fc4500000000000000000000000000000000000000000000000000000000ee6b2800",
+    nonce: "1024", transactionIndex: 2,
+    r: "0x7890abcdef1234567890abcdef1234567890abcdef1234567890abcdef123456",
+    s: "0x34567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef12", v: "0x1c"
   }) { hash }
 
-  l3_9_1: create_Log(input: {
-    address: "0x96e2e0a98a386df5c325606ad327f28a0053ee1b",
-    topics: ["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", "0x4dd67b2a0e0a64c03372074f94ab37d11a3319a1496e6c2af6cc4e26bc76b710", "0xaad2b9e72acc7f5bb33c97c147ff5e05dcd0a7952c882d213ea6a9d81b31604f"],
-    data: "0x084fd6d43888e37a60d1dfc80558e8ab37ae4f3e860d33c816962f6feb776c9fe0837003b6d054c4b851825721b",
-    transactionHash: "0x04eb01061bcc3b60bc9386e9de1f03f5d1036db317899841cf8adcb591c443ab",
-    blockHash: "0xe51a4a546c2d3130857af3abcc7bd37e4603f4297c96360009365228e3dbc09a",
-    blockNumber: 20483212,
-    transactionIndex: "8",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e3_9_1: create_Event(input: {
-    contractAddress: "0x96e2e0a98a386df5c325606ad327f28a0053ee1b",
-    eventName: "Approval",
-    parameters: "{\"owner\":\"0xdf4ad55530a769e08f9fc99ab7da5377a0f249ab\",\"spender\":\"0x635107c4522f74ef5d87baaa5595b4a3c3afb2e2\",\"value\":\"0\"}",
-    transactionHash: "0x04eb01061bcc3b60bc9386e9de1f03f5d1036db317899841cf8adcb591c443ab",
-    blockHash: "0xe51a4a546c2d3130857af3abcc7bd37e4603f4297c96360009365228e3dbc09a",
-    blockNumber: 20483212,
-    transactionIndex: "8",
-    logIndex: "0"
-  }) { eventName }
-
-  t3_10: create_Transaction(input: {
-    hash: "0xee4088201f83658b721f93448e0f4c8d655b2f94590865d331169cd3c61f04ce",
-    blockHash: "0xe51a4a546c2d3130857af3abcc7bd37e4603f4297c96360009365228e3dbc09a",
-    blockNumber: 20483212,
-    from: "0x51411a7cd42b6d00aefa013f74a00e6e261e5523",
-    to: "0x6c1f2cf45308a8d3f352f0e897d1479945b42c04",
-    value: "1000",
-    gasUsed: "68470",
-    gasPrice: "15000000000",
-    inputData: "0x24089ef5c065dba374fd2e9048bbb3c143",
-    nonce: "27",
-    transactionIndex: "9",
-    r: "0x3a25dc9d8fdd46ec1089e807e231f942d911c6c46a788d8e1537da8d5405256f",
-    s: "0x40ba0660100c79ce73002383c002c474f6ee1c0a92df8c7110877d337e232a2b",
-    v: "0x1c"
+  t2_4: add_Ethereum__Mainnet__Transaction(input: {
+    hash: "0xef03dai03c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f",
+    blockHash: "0x5f4b4865521288f7a48ef2f95bba69ea239f9d2b3369d6f96eb9f2de826b2cee",
+    blockNumber: 18500001,
+    from: "0xBE0eB53F46cd790Cd13851d5EFf43D12404d33E8",
+    to: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+    value: "0", gasUsed: "60000", gasPrice: "31000000000",
+    input: "0xa9059cbb000000000000000000000000d8dA6BF26964aF9D7eEd9e03E53415D37aA960450000000000000000000000000000000000000000000000056bc75e2d63100000",
+    nonce: "9002", transactionIndex: 3,
+    r: "0xeeee1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcd",
+    s: "0xffff0abcdef1234567890abcdef1234567890abcdef1234567890abcdef12345678", v: "0x1c"
   }) { hash }
 
-  l3_10_1: create_Log(input: {
-    address: "0x49406802b6a78dd0eac898cde413148042447e90",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0xc41b2f8a4e7b6d957be0092534a33d25ab09c311e5718dd012474e202564d2b2", "0x408b0fdda789c1954ed79c032a70bf69f487bd2fd55a34e5ce0cdcbc4482ede8"],
-    data: "0xfe2516b01d39f9447a86919dc4342ad8b5b850c89233f624e70d797a9528d0cc80b331525b96825703c19d07f43c1165163e1",
-    transactionHash: "0xee4088201f83658b721f93448e0f4c8d655b2f94590865d331169cd3c61f04ce",
-    blockHash: "0xe51a4a546c2d3130857af3abcc7bd37e4603f4297c96360009365228e3dbc09a",
-    blockNumber: 20483212,
-    transactionIndex: "9",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e3_10_1: create_Event(input: {
-    contractAddress: "0x49406802b6a78dd0eac898cde413148042447e90",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0x51411a7cd42b6d00aefa013f74a00e6e261e5523\",\"to\":\"0x6c1f2cf45308a8d3f352f0e897d1479945b42c04\",\"value\":\"1000\"}",
-    transactionHash: "0xee4088201f83658b721f93448e0f4c8d655b2f94590865d331169cd3c61f04ce",
-    blockHash: "0xe51a4a546c2d3130857af3abcc7bd37e4603f4297c96360009365228e3dbc09a",
-    blockNumber: 20483212,
-    transactionIndex: "9",
-    logIndex: "0"
-  }) { eventName }
-
-  b4: create_Block(input: {
-    hash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    number: 20483213,
-    timestamp: "2023-07-01T12:06:00Z",
-    parentHash: "0xe51a4a546c2d3130857af3abcc7bd37e4603f4297c96360009365228e3dbc09a",
-    difficulty: "1002900",
-    gasUsed: "21279424",
-    gasLimit: "30000000",
-    nonce: "0x37b42a13d94c20f0",
-    miner: "0xa71ed30590bbe10589646c553c1ccbe8cf0ceb2d",
-    size: "1222",
-    stateRoot: "0x8f21d02ee062c6e1a019665de588c73e58ed7071ca815ba3774e5f5253c7b19d",
-    sha3Uncles: "0x6b1859637499270093d20a7143b2cfbc9c77a79220a038fd84fd3af7aa342efa",
-    transactionsRoot: "0x347bf3ab84c1e57c0499db8dee41b2e30e61e3bc8f7f163fa9705e929ae5c155",
-    receiptsRoot: "0xa8cc4e591edd840ec64f26a6cfd4b46df1d08c751ab780b04f6d2aed80a6ade1",
-    extraData: "0xfefab85d207845f6c4e651554f332ebfd3f3d5195b398c71b53d065505d0385c"
+  t2_5: add_Ethereum__Mainnet__Transaction(input: {
+    hash: "0xa104weth4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a",
+    blockHash: "0x5f4b4865521288f7a48ef2f95bba69ea239f9d2b3369d6f96eb9f2de826b2cee",
+    blockNumber: 18500001,
+    from: "0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD",
+    to: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+    value: "0", gasUsed: "55000", gasPrice: "32000000000",
+    input: "0xa9059cbb000000000000000000000000F977814e90dA44bFA03b6295A0616a897441aceC00000000000000000000000000000000000000000000000029a2241af62c0000",
+    nonce: "222", transactionIndex: 4,
+    r: "0x11111234567890abcdef1234567890abcdef1234567890abcdef1234567890abcd",
+    s: "0x22220abcdef1234567890abcdef1234567890abcdef1234567890abcdef12345678", v: "0x1b"
   }) { hash }
 
-  t4_1: create_Transaction(input: {
-    hash: "0x14ddeca5e59b6f8b0e0d90dfbd0510351552b971881755b6765057b214bab137",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    from: "0xa9a17c96676597c5d400b73488251eaca41347fc",
-    to: "0x62fe9b8520c5826ea345ce273fb7c4d8fa4c8c34",
-    value: "0",
-    gasUsed: "183741",
-    gasPrice: "25000000000",
-    inputData: "0xe70058a4816532b",
-    nonce: "176",
-    transactionIndex: "0",
-    r: "0x7ab0a386433971efe48e4b844278a3509ff1dfc6675db3b15ae9d81ab65adf4c",
-    s: "0x508cf45b96ab2c5555b035bc59e5d68502557829500dc5e14dc08a1bd652f910",
-    v: "0x1b"
+  t3_1: add_Ethereum__Mainnet__Transaction(input: {
+    hash: "0x229ef03dea0bcbf7a8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9fa0b",
+    blockHash: "0x6a5c5976632399a8b59f3fa6ccb7aefb34af0e3c4480e7fa7fc0a3ef937c3dff",
+    blockNumber: 18500002,
+    from: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+    to: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    value: "0", gasUsed: "65000", gasPrice: "27000000000",
+    input: "0xa9059cbb000000000000000000000000DFd5293D8e347dFe59E90eFd55b2956a1343963d0000000000000000000000000000000000000000000000000000000000989680",
+    nonce: "512", transactionIndex: 0,
+    r: "0xcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab",
+    s: "0x4567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234", v: "0x1b"
   }) { hash }
 
-  l4_1_1: create_Log(input: {
-    address: "0x21277b65459e227c01d04ef1ac8c3d1fd4c96b00",
-    topics: ["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", "0x7e568d2ed47366d30892d9463cb8936e5efcbfd1d689518d2faa3e02f6595159", "0x7e9882f578bda6c8e05b9b7c4d18e56d8200a7aaf852c87a017f28d19fd397e8"],
-    data: "0x6e1cc2ebd8de4c7c2b92b114ef5309a1ec097bdd1a177e8d760cfe60cf3455ddf820eda6a1cf6d695fc0aa09443e18d2ce0",
-    transactionHash: "0x14ddeca5e59b6f8b0e0d90dfbd0510351552b971881755b6765057b214bab137",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "0",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e4_1_1: create_Event(input: {
-    contractAddress: "0x21277b65459e227c01d04ef1ac8c3d1fd4c96b00",
-    eventName: "Approval",
-    parameters: "{\"owner\":\"0xa9a17c96676597c5d400b73488251eaca41347fc\",\"spender\":\"0x62fe9b8520c5826ea345ce273fb7c4d8fa4c8c34\",\"value\":\"0\"}",
-    transactionHash: "0x14ddeca5e59b6f8b0e0d90dfbd0510351552b971881755b6765057b214bab137",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "0",
-    logIndex: "0"
-  }) { eventName }
-
-  l4_1_2: create_Log(input: {
-    address: "0xdc6512c50f6525f34da67e2e0d985c9506727a90",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0x9bde0c52ae60b858787142e3df0cc873a13c842a06e13f14d91e16012e5c45d5", "0x99a00e4a5e822d0d3c35fcc4014073e15d68886ac58af02509495b6d0247eb70"],
-    data: "0x8ec17ce0497ca491bb7d82eb807c843bef7b8cd4647d1cced924b9f54185c55d40cdc2ed56bc476afcefe5b",
-    transactionHash: "0x14ddeca5e59b6f8b0e0d90dfbd0510351552b971881755b6765057b214bab137",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "0",
-    logIndex: "1",
-    removed: "false"
-  }) { address }
-
-  e4_1_2: create_Event(input: {
-    contractAddress: "0xdc6512c50f6525f34da67e2e0d985c9506727a90",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0xa9a17c96676597c5d400b73488251eaca41347fc\",\"to\":\"0x62fe9b8520c5826ea345ce273fb7c4d8fa4c8c34\",\"value\":\"0\"}",
-    transactionHash: "0x14ddeca5e59b6f8b0e0d90dfbd0510351552b971881755b6765057b214bab137",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "0",
-    logIndex: "1"
-  }) { eventName }
-
-  t4_2: create_Transaction(input: {
-    hash: "0xd0937851873a66244c0002991ec429719269306fa4f41dac95490a4157a70fdd",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    from: "0x38c41bc402fb70edd3daf490979f835a726fac30",
-    to: "0x1fff652fb17d2514a26f66e1695998e908fd0ed4",
-    value: "100",
-    gasUsed: "103631",
-    gasPrice: "10000000000",
-    inputData: "0x",
-    nonce: "177",
-    transactionIndex: "1",
-    r: "0xfda22f1b2f75b28bc6812b0bb23ae88cb73c1ff0190709a9380745206cc517bc",
-    s: "0x80e04ca5a2c9d667ad4616e9801df1f15132972264cc33a8a1a5c7533c19e540",
-    v: "0x1c"
+  t3_2: add_Ethereum__Mainnet__Transaction(input: {
+    hash: "0x33af014efb1cdca8b9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9fa0b1c",
+    blockHash: "0x6a5c5976632399a8b59f3fa6ccb7aefb34af0e3c4480e7fa7fc0a3ef937c3dff",
+    blockNumber: 18500002,
+    from: "0x5041ed759Dd4aFc3a72b8192C143F72f4724081A",
+    to: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    value: "0", gasUsed: "65000", gasPrice: "28000000000",
+    input: "0xa9059cbb00000000000000000000000047ac0Fb4F2D84898e4D9E7b4DaB3C24507a6D503000000000000000000000000000000000000000000000000000000012a05f200",
+    nonce: "89", transactionIndex: 1,
+    r: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+    s: "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890", v: "0x1c"
   }) { hash }
 
-  l4_2_1: create_Log(input: {
-    address: "0xf0ff8b89f1462e29c2a78dfcd4d57ac0b704c290",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0xbfe06cc1a1c71cc7d0b142d803061351704b408a56ebeb735c11d14ebf9a8841", "0xa999a72303cbb699acc55b43ff1adc07d3d49d0e09e4dc046b2bb02b602e72df"],
-    data: "0xad1be1b4589267a9e81c8b63ae1ae32cd9c6dac376af8ec0be157ff28703550bdf7664f646c9",
-    transactionHash: "0xd0937851873a66244c0002991ec429719269306fa4f41dac95490a4157a70fdd",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "1",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e4_2_1: create_Event(input: {
-    contractAddress: "0xf0ff8b89f1462e29c2a78dfcd4d57ac0b704c290",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0x38c41bc402fb70edd3daf490979f835a726fac30\",\"to\":\"0x1fff652fb17d2514a26f66e1695998e908fd0ed4\",\"value\":\"100\"}",
-    transactionHash: "0xd0937851873a66244c0002991ec429719269306fa4f41dac95490a4157a70fdd",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "1",
-    logIndex: "0"
-  }) { eventName }
-
-  t4_3: create_Transaction(input: {
-    hash: "0x8154a75cec585ef757a4147503802d67589469f240faa2a8a4c1ead267300c97",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    from: "0x645d44feee662d1cc9f0e06b17c1aa594921f914",
-    to: "0xf80dfb5ded4b0d5017c6bc8d29e8af636f828d1a",
-    value: "1000",
-    gasUsed: "24724",
-    gasPrice: "17000000000",
-    inputData: "0x4dd964478c343523a9a780025e",
-    nonce: "111",
-    transactionIndex: "2",
-    r: "0x5469f955acef2446ef1a92c1c268bc9e8c0ade8c670e46c3114d2cc403dabaed",
-    s: "0x8afcaabfb358fd8001cead491b2dcb8a3458982f90466dd07af12e07d619846d",
-    v: "0x1b"
+  t3_3: add_Ethereum__Mainnet__Transaction(input: {
+    hash: "0x44b0125fac2eddb9c0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9fa0b1c2d",
+    blockHash: "0x6a5c5976632399a8b59f3fa6ccb7aefb34af0e3c4480e7fa7fc0a3ef937c3dff",
+    blockNumber: 18500002,
+    from: "0xE592427A0AEce92De3Edee1F18E0157C05861564",
+    to: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    value: "0", gasUsed: "65000", gasPrice: "26000000000",
+    input: "0xa9059cbb00000000000000000000000056Eddb7aa87536c09CCc2793473599fD21A8b17F0000000000000000000000000000000000000000000000000000000077359400",
+    nonce: "3001", transactionIndex: 2,
+    r: "0x890abcdef1234567890abcdef1234567890abcdef1234567890abcdef12345678",
+    s: "0xef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef", v: "0x1b"
   }) { hash }
 
-  l4_3_1: create_Log(input: {
-    address: "0x1a17082680d2fff48a4836bc809a1e6bcf90af78",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0xa14d05884172b4a80e694173eef9debb392d85604ac83d5775d0bc85edf963e6", "0x0cc562b22e494cba9d0d474e47f3e0457f11da8e18eea82edfaa621e6e2b2af1"],
-    data: "0xbc5c68ed6040fc247c3530a234c340f0cc131e47f44c778d9e17a1dfaed76abe0fe73563aaa1ae1b42f788819b632929f1347a",
-    transactionHash: "0x8154a75cec585ef757a4147503802d67589469f240faa2a8a4c1ead267300c97",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "2",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e4_3_1: create_Event(input: {
-    contractAddress: "0x1a17082680d2fff48a4836bc809a1e6bcf90af78",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0x645d44feee662d1cc9f0e06b17c1aa594921f914\",\"to\":\"0xf80dfb5ded4b0d5017c6bc8d29e8af636f828d1a\",\"value\":\"1000\"}",
-    transactionHash: "0x8154a75cec585ef757a4147503802d67589469f240faa2a8a4c1ead267300c97",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "2",
-    logIndex: "0"
-  }) { eventName }
-
-  t4_4: create_Transaction(input: {
-    hash: "0x16ce3ac21eee14798bd98df907dd902d64af6f63bfbe54e73c6142ab9577592c",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    from: "0xb2b87dc0e699cf8c53bb92f83d2e0a05523c2937",
-    to: "0x98fc186fe9044c97604db0c536dcee3cddd204ac",
-    value: "100",
-    gasUsed: "93845",
-    gasPrice: "12000000000",
-    inputData: "0x4447",
-    nonce: "68",
-    transactionIndex: "3",
-    r: "0x126ed7dfb03fe2a498c3890567b2e9cbd94c13c7f4c62bcab55fec829106a05a",
-    s: "0xa26898cf45709f7728b8c2bf964b238eea624090a97efdd361b113f72962a228",
-    v: "0x1b"
+  t3_4: add_Ethereum__Mainnet__Transaction(input: {
+    hash: "0xb205usdt5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b",
+    blockHash: "0x6a5c5976632399a8b59f3fa6ccb7aefb34af0e3c4480e7fa7fc0a3ef937c3dff",
+    blockNumber: 18500002,
+    from: "0x47ac0Fb4F2D84898e4D9E7b4DaB3C24507a6D503",
+    to: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+    value: "0", gasUsed: "46000", gasPrice: "27000000000",
+    input: "0x095ea7b3000000000000000000000000E592427A0AEce92De3Edee1F18E0157C05861564ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    nonce: "783", transactionIndex: 3,
+    r: "0x33331234567890abcdef1234567890abcdef1234567890abcdef1234567890abcd",
+    s: "0x44440abcdef1234567890abcdef1234567890abcdef1234567890abcdef12345678", v: "0x1c"
   }) { hash }
 
-  l4_4_1: create_Log(input: {
-    address: "0xfd530f2e31cad94ae1d04d672b8560c115615daa",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0xa45933940cdf13a28a403cd764444811a74551bc403123689673675b5c36578a", "0xd9a4695c99ed058dd6851b7def78b5f7bc2a5ccba28fc5b71dd938fb77cb59e8"],
-    data: "0xda7a6d4a7496cf493af25ed67a869dad70d3c49f72d3b723c6e2070f6f4c1f5038df04c863439c69ec5a845c9bc663e4906c8235dc9e2de0d7",
-    transactionHash: "0x16ce3ac21eee14798bd98df907dd902d64af6f63bfbe54e73c6142ab9577592c",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "3",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e4_4_1: create_Event(input: {
-    contractAddress: "0xfd530f2e31cad94ae1d04d672b8560c115615daa",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0xb2b87dc0e699cf8c53bb92f83d2e0a05523c2937\",\"to\":\"0x98fc186fe9044c97604db0c536dcee3cddd204ac\",\"value\":\"100\"}",
-    transactionHash: "0x16ce3ac21eee14798bd98df907dd902d64af6f63bfbe54e73c6142ab9577592c",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "3",
-    logIndex: "0"
-  }) { eventName }
-
-  l4_4_2: create_Log(input: {
-    address: "0x6a7313c35b03c7812677886fdf683918212df612",
-    topics: ["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", "0x23c092019514dd3c121794368a98416a62d1f3f36c12af32f36439049e052923", "0x4e9a4f26dfbfc9d62721f93c395743b91272a6a1dd5c2d8ba5a5f9204b9f2e8b"],
-    data: "0xc9710b3adebc6bb945e2e4cc4bcb08c0f01298370cd581e300dd183f440fd5633b54744554908fa46b9108218e37b337b0a6ae4540d93bf1e70402",
-    transactionHash: "0x16ce3ac21eee14798bd98df907dd902d64af6f63bfbe54e73c6142ab9577592c",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "3",
-    logIndex: "1",
-    removed: "false"
-  }) { address }
-
-  e4_4_2: create_Event(input: {
-    contractAddress: "0x6a7313c35b03c7812677886fdf683918212df612",
-    eventName: "Approval",
-    parameters: "{\"owner\":\"0xb2b87dc0e699cf8c53bb92f83d2e0a05523c2937\",\"spender\":\"0x98fc186fe9044c97604db0c536dcee3cddd204ac\",\"value\":\"100\"}",
-    transactionHash: "0x16ce3ac21eee14798bd98df907dd902d64af6f63bfbe54e73c6142ab9577592c",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "3",
-    logIndex: "1"
-  }) { eventName }
-
-  t4_5: create_Transaction(input: {
-    hash: "0x0939a792a4389fde9415270c7bf07e3437e87c0aaabfb90850dd19b4d0c21cad",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    from: "0xe77e8be12ca4ed27d2914b7086fc5c989ef5a095",
-    to: "0x7485690182e493aa7c3aaae90c5fc0585be17674",
-    value: "1000",
-    gasUsed: "198119",
-    gasPrice: "60000000000",
-    inputData: "0xb572a4c71804dc52e53f9544092de53b75cc6",
-    nonce: "121",
-    transactionIndex: "4",
-    r: "0x0c74b1637519b0541d313776b7ff210105ad3c45ac8f2bb90e4709b6472cee29",
-    s: "0xac9e97e039b632efddda1b5fd24052af1d2144723cfe0cfd6a7446f3b424c9bd",
-    v: "0x1b"
+  t3_5: add_Ethereum__Mainnet__Transaction(input: {
+    hash: "0xc306dai06f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c",
+    blockHash: "0x6a5c5976632399a8b59f3fa6ccb7aefb34af0e3c4480e7fa7fc0a3ef937c3dff",
+    blockNumber: 18500002,
+    from: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+    to: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+    value: "0", gasUsed: "46000", gasPrice: "26000000000",
+    input: "0x095ea7b300000000000000000000000068b3465833fb72A70ecDF485E0e4C7bD8665Fc45ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    nonce: "513", transactionIndex: 4,
+    r: "0x55551234567890abcdef1234567890abcdef1234567890abcdef1234567890abcd",
+    s: "0x66660abcdef1234567890abcdef1234567890abcdef1234567890abcdef12345678", v: "0x1b"
   }) { hash }
-
-  l4_5_1: create_Log(input: {
-    address: "0x2294960107ea7472648dbcc64f83f6fda2a64133",
-    topics: ["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", "0x0cb5dc95de7b24f58ab77fbcacfd8e9d5589b309d4a0d4daca341d4edf57a0e6", "0x8842439db05469fe09bfe4b391e067429e476e418a2cfce0c6d74d6032440198"],
-    data: "0xc8666dec05cf26c0a89d40bd813648b26b1023a9c3fb1161982191872bcca26a6386f9eab16103ca",
-    transactionHash: "0x0939a792a4389fde9415270c7bf07e3437e87c0aaabfb90850dd19b4d0c21cad",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "4",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e4_5_1: create_Event(input: {
-    contractAddress: "0x2294960107ea7472648dbcc64f83f6fda2a64133",
-    eventName: "Approval",
-    parameters: "{\"owner\":\"0xe77e8be12ca4ed27d2914b7086fc5c989ef5a095\",\"spender\":\"0x7485690182e493aa7c3aaae90c5fc0585be17674\",\"value\":\"1000\"}",
-    transactionHash: "0x0939a792a4389fde9415270c7bf07e3437e87c0aaabfb90850dd19b4d0c21cad",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "4",
-    logIndex: "0"
-  }) { eventName }
-
-  l4_5_2: create_Log(input: {
-    address: "0xc9e3fe81214e3c6f3d23bcdd32fceb665d2f1a0a",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0xb68b2bdae4b7b77595cc43efa12a8ddf60604a65e5fcd78a2b15a4b9d370e60f", "0x40e75fffe3394a4fc6010e2421484699f61bfef3d3f3cbdbcced91c769800b45"],
-    data: "0x4cb6e65422870e0b9f7d13af32a1312c4d0014cb68eae67a96bf2539cf28c7dc974062f4ddb449ca85f4901140c129c0a20a",
-    transactionHash: "0x0939a792a4389fde9415270c7bf07e3437e87c0aaabfb90850dd19b4d0c21cad",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "4",
-    logIndex: "1",
-    removed: "false"
-  }) { address }
-
-  e4_5_2: create_Event(input: {
-    contractAddress: "0xc9e3fe81214e3c6f3d23bcdd32fceb665d2f1a0a",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0xe77e8be12ca4ed27d2914b7086fc5c989ef5a095\",\"to\":\"0x7485690182e493aa7c3aaae90c5fc0585be17674\",\"value\":\"1000\"}",
-    transactionHash: "0x0939a792a4389fde9415270c7bf07e3437e87c0aaabfb90850dd19b4d0c21cad",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "4",
-    logIndex: "1"
-  }) { eventName }
-
-  t4_6: create_Transaction(input: {
-    hash: "0x864f3c6167ad6c602111172e309157a82a517187edd27dc50244d2b9e8e0b722",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    from: "0x1b670df6e943394d7fdb03cfdf3ffc46d7db02c5",
-    to: "0xec555ddde06ec2ca550e97a34aaffe4dafc906b0",
-    value: "1000",
-    gasUsed: "28687",
-    gasPrice: "10000000000",
-    inputData: "0x3e3caf624bcb2e239d11b105885efbe170460",
-    nonce: "31",
-    transactionIndex: "5",
-    r: "0x34a02c1f850cb45576d630c510f60485cd48eb7f90af289cbdf81cf6b98b78a2",
-    s: "0x8cddb68697bd5df6dc9a740efbf0975d6897da1b09a1b158ce501e68561ee7f4",
-    v: "0x1c"
-  }) { hash }
-
-  l4_6_1: create_Log(input: {
-    address: "0xb0702d4ab3b1409a05396a724e877fa623347b08",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0xcb5e84dc5b31bf76bb9a28d127a32f9bba7e1d4f53de67e8c342afbd5d835d08", "0x3ec501d72d707a2df19a1a44de73568719b29414b7c9b14573784fbbece523a9"],
-    data: "0x9862697db7215ff33a0d43e4ca2e653d421f74537c2ae6edf30b4ef0e9b2b6188a1",
-    transactionHash: "0x864f3c6167ad6c602111172e309157a82a517187edd27dc50244d2b9e8e0b722",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "5",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e4_6_1: create_Event(input: {
-    contractAddress: "0xb0702d4ab3b1409a05396a724e877fa623347b08",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0x1b670df6e943394d7fdb03cfdf3ffc46d7db02c5\",\"to\":\"0xec555ddde06ec2ca550e97a34aaffe4dafc906b0\",\"value\":\"1000\"}",
-    transactionHash: "0x864f3c6167ad6c602111172e309157a82a517187edd27dc50244d2b9e8e0b722",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "5",
-    logIndex: "0"
-  }) { eventName }
-
-  t4_7: create_Transaction(input: {
-    hash: "0x0504c7f169b15acec1718068deb9247d31274e521a3778c139540375b75162c3",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    from: "0xd7d072f7c0e9fdf5110b42831f0e3d78b0a356e0",
-    to: "0xb23289b8bdf4cbac35edf27ee3d4d7bc34cce70b",
-    value: "1000",
-    gasUsed: "150608",
-    gasPrice: "15000000000",
-    inputData: "0x36f915469c299cc5fd660932ed3953b5973cd6d8f08caccf06c70087f7",
-    nonce: "102",
-    transactionIndex: "6",
-    r: "0x72b5435f1ca782181c432e5458f36023ec1fae8f9e1a543f338dadb330d2f6ad",
-    s: "0x73d635ebbe5d3d9d6f2261c51360f2dfb653c76d372fa811917f5b9ba7ad734f",
-    v: "0x1c"
-  }) { hash }
-
-  l4_7_1: create_Log(input: {
-    address: "0x644aa3e825a28fd5356c13c78b8368a73ac6170f",
-    topics: ["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", "0xa1d9be48153ef6a2dc2266f6de0f43f790594558371d757da903399859840587", "0xb09edb23d2ad80939fb626e1a949a215c2206aca855157fccdd55b77c2822607"],
-    data: "0x48490cd568d6697786fb3cd81db95975c4aa0e86a0b5b8f07dd9a6a3fca18e3601a84e689ccdde8e0d3e0d128e22068e3acfbdd",
-    transactionHash: "0x0504c7f169b15acec1718068deb9247d31274e521a3778c139540375b75162c3",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "6",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e4_7_1: create_Event(input: {
-    contractAddress: "0x644aa3e825a28fd5356c13c78b8368a73ac6170f",
-    eventName: "Approval",
-    parameters: "{\"owner\":\"0xd7d072f7c0e9fdf5110b42831f0e3d78b0a356e0\",\"spender\":\"0xb23289b8bdf4cbac35edf27ee3d4d7bc34cce70b\",\"value\":\"1000\"}",
-    transactionHash: "0x0504c7f169b15acec1718068deb9247d31274e521a3778c139540375b75162c3",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "6",
-    logIndex: "0"
-  }) { eventName }
-
-  l4_7_2: create_Log(input: {
-    address: "0xa0a2d03cf985696bda08a0add7fa91485d2f5ae3",
-    topics: ["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", "0x14a17afd5c92d797d1c6ab702024eca2609b4febcf16cad416d689968cc77324", "0x67bed2f1e73e98beed5d4c7cea1ff8fb8979a4b6ee807fcedf90840fdeb29eb6"],
-    data: "0x22af66111181dbcb4798a7adb7a564dd1018e022179bd22ca223a6e8cd299fed2df08edcc40b4bcab028577055fd90a8f7d542",
-    transactionHash: "0x0504c7f169b15acec1718068deb9247d31274e521a3778c139540375b75162c3",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "6",
-    logIndex: "1",
-    removed: "false"
-  }) { address }
-
-  e4_7_2: create_Event(input: {
-    contractAddress: "0xa0a2d03cf985696bda08a0add7fa91485d2f5ae3",
-    eventName: "Approval",
-    parameters: "{\"owner\":\"0xd7d072f7c0e9fdf5110b42831f0e3d78b0a356e0\",\"spender\":\"0xb23289b8bdf4cbac35edf27ee3d4d7bc34cce70b\",\"value\":\"1000\"}",
-    transactionHash: "0x0504c7f169b15acec1718068deb9247d31274e521a3778c139540375b75162c3",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "6",
-    logIndex: "1"
-  }) { eventName }
-
-  l4_7_3: create_Log(input: {
-    address: "0x81b262cc19f9e7628ea58e99406a893057f7b2dd",
-    topics: ["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", "0xff93626b2604bb68da2b6b53faa1925cab3ceb566379211628c6845953be7135", "0x2a4f69229c2672abb612a7161990ee231db9aaedd79a93534d8a41d9230d3cc2"],
-    data: "0x145843c4d442fbc5cc4068f200b74bf44e165401e8af486e34b29a51a04c0c1905",
-    transactionHash: "0x0504c7f169b15acec1718068deb9247d31274e521a3778c139540375b75162c3",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "6",
-    logIndex: "2",
-    removed: "false"
-  }) { address }
-
-  e4_7_3: create_Event(input: {
-    contractAddress: "0x81b262cc19f9e7628ea58e99406a893057f7b2dd",
-    eventName: "Approval",
-    parameters: "{\"owner\":\"0xd7d072f7c0e9fdf5110b42831f0e3d78b0a356e0\",\"spender\":\"0xb23289b8bdf4cbac35edf27ee3d4d7bc34cce70b\",\"value\":\"1000\"}",
-    transactionHash: "0x0504c7f169b15acec1718068deb9247d31274e521a3778c139540375b75162c3",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "6",
-    logIndex: "2"
-  }) { eventName }
-
-  t4_8: create_Transaction(input: {
-    hash: "0x580db9f8eca1082adc8613cabd47fecbd726c1d440236c08f8e20606a38a7599",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    from: "0x238e1b79e47b2df61a74cf08cdac45b55503647b",
-    to: "0x61dad9dfdf0c8a7f88afa427b62faba5f8e8229c",
-    value: "10",
-    gasUsed: "133339",
-    gasPrice: "30000000000",
-    inputData: "0x33fd8a78dba2bd93ced7016b513c612af45844869",
-    nonce: "197",
-    transactionIndex: "7",
-    r: "0x5fcd18d1218066902a7e7bccf3ba88d0b74c1df8c4f41a6c9234bde4b152ba67",
-    s: "0x0feaa425c5d86bcf89c0e0fa232efbb2489395a63d857af8eedbca1f0ba98697",
-    v: "0x1c"
-  }) { hash }
-
-  l4_8_1: create_Log(input: {
-    address: "0xff3ad54081fc793b6bee31133a8ee798728f45bb",
-    topics: ["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", "0xac837a8f93cabe6a474bbb0bf9fb3dc14836d5769e090e38ce38ff793baa16f9", "0xbc13e06c302eb013e1ce81fd5aa3c43b7dec7b6df7bbd1f1e4468267b3602861"],
-    data: "0x95f97dc7afde280601e7bdb4c05a5d7f824cd324465285a5c23f4a9cae88cb65ba89233a26ce60a41636ed938f28c45028767a81335e56c060fc9ef10df",
-    transactionHash: "0x580db9f8eca1082adc8613cabd47fecbd726c1d440236c08f8e20606a38a7599",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "7",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e4_8_1: create_Event(input: {
-    contractAddress: "0xff3ad54081fc793b6bee31133a8ee798728f45bb",
-    eventName: "Approval",
-    parameters: "{\"owner\":\"0x238e1b79e47b2df61a74cf08cdac45b55503647b\",\"spender\":\"0x61dad9dfdf0c8a7f88afa427b62faba5f8e8229c\",\"value\":\"10\"}",
-    transactionHash: "0x580db9f8eca1082adc8613cabd47fecbd726c1d440236c08f8e20606a38a7599",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "7",
-    logIndex: "0"
-  }) { eventName }
-
-  l4_8_2: create_Log(input: {
-    address: "0xd37ec4b0fdf2d53f419c193c7175c9ac8de932c1",
-    topics: ["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", "0x70c81f0794a3e132b36c4ce0e853a727c4a5c0453d0eb80476b79620dbe7a2f9", "0xa8c6b30529124762abf07ae3ff2f061bde19248c0a2c87a67ec83eceed10c879"],
-    data: "0xe72f717758deaf8a309819e632bc0a95f1eb9fd3331ffc9eb9bdae4e45c69a80608cbd0dc5d264df1eeeebe16d4c7fe5e221e7b34",
-    transactionHash: "0x580db9f8eca1082adc8613cabd47fecbd726c1d440236c08f8e20606a38a7599",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "7",
-    logIndex: "1",
-    removed: "false"
-  }) { address }
-
-  e4_8_2: create_Event(input: {
-    contractAddress: "0xd37ec4b0fdf2d53f419c193c7175c9ac8de932c1",
-    eventName: "Approval",
-    parameters: "{\"owner\":\"0x238e1b79e47b2df61a74cf08cdac45b55503647b\",\"spender\":\"0x61dad9dfdf0c8a7f88afa427b62faba5f8e8229c\",\"value\":\"10\"}",
-    transactionHash: "0x580db9f8eca1082adc8613cabd47fecbd726c1d440236c08f8e20606a38a7599",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "7",
-    logIndex: "1"
-  }) { eventName }
-
-  t4_9: create_Transaction(input: {
-    hash: "0xd551d5965767146788c0c0c870cb46aeca4924a7f11c88a9fa733085bb940a7e",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    from: "0xd94ba0fdec051745372f12acd64ff5f62859bd53",
-    to: "0xfc993d07650f00a215f9a2404502fb9b82c8f421",
-    value: "500",
-    gasUsed: "127375",
-    gasPrice: "25000000000",
-    inputData: "0xea03b5ce88517c1f",
-    nonce: "136",
-    transactionIndex: "8",
-    r: "0xa9660bf476c0d128ae474cf28a3e03b13dff404b24134b4774e086fa53aba32d",
-    s: "0x6e2950eae93959e7d5c4b27259fe7def589696a9ef5cbf3ac97151780949fd10",
-    v: "0x1b"
-  }) { hash }
-
-  l4_9_1: create_Log(input: {
-    address: "0x902dbf7fd495cc44b8417d712813a4e733e55c92",
-    topics: ["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", "0xfad0028476a8e9557addff2b7055d59e7ca0164011d9ed2994ef7aa819573cf4", "0x1deb87697c08a65b5f7ae673770f78a76157d93549f80b6e5177b1a2c1474a30"],
-    data: "0x2bbaf1818449ac9225bb24a71f227b0b7982f3afabf3cd7548d70d3d42bd7a400ed2a1941acbdee2966d0113129d3164f3618c3c73dfb2bd1b1cac5cf510f4",
-    transactionHash: "0xd551d5965767146788c0c0c870cb46aeca4924a7f11c88a9fa733085bb940a7e",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "8",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e4_9_1: create_Event(input: {
-    contractAddress: "0x902dbf7fd495cc44b8417d712813a4e733e55c92",
-    eventName: "Approval",
-    parameters: "{\"owner\":\"0xd94ba0fdec051745372f12acd64ff5f62859bd53\",\"spender\":\"0xfc993d07650f00a215f9a2404502fb9b82c8f421\",\"value\":\"500\"}",
-    transactionHash: "0xd551d5965767146788c0c0c870cb46aeca4924a7f11c88a9fa733085bb940a7e",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "8",
-    logIndex: "0"
-  }) { eventName }
-
-  l4_9_2: create_Log(input: {
-    address: "0xf5039e46e6bd90e7071ceb38b96de28cf81dcdeb",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0xaf32d9bd1bbc69721e64014bbda67fff7063cff35d3b9f4034814b9aa01a9116", "0xfce7f49c3c606977100297a5970f83eda8dc4f6b3c54a4eac1054714791bcee3"],
-    data: "0xb2b18350a2dcd13564f98f1c6d2a4fca9994045848c627e7e29b172314cc3837d0c208e2334ac49fd692178",
-    transactionHash: "0xd551d5965767146788c0c0c870cb46aeca4924a7f11c88a9fa733085bb940a7e",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "8",
-    logIndex: "1",
-    removed: "false"
-  }) { address }
-
-  e4_9_2: create_Event(input: {
-    contractAddress: "0xf5039e46e6bd90e7071ceb38b96de28cf81dcdeb",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0xd94ba0fdec051745372f12acd64ff5f62859bd53\",\"to\":\"0xfc993d07650f00a215f9a2404502fb9b82c8f421\",\"value\":\"500\"}",
-    transactionHash: "0xd551d5965767146788c0c0c870cb46aeca4924a7f11c88a9fa733085bb940a7e",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "8",
-    logIndex: "1"
-  }) { eventName }
-
-  t4_10: create_Transaction(input: {
-    hash: "0x2826233390a275a3e099e1bd081ce39e620638bc8af44eaf81e8076e88e07737",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    from: "0xc925c920c075deb721bfc72120ca9d35a7c1c901",
-    to: "0x8e9ce9c882e07c301ee02ef7fa9661e332e3d118",
-    value: "0",
-    gasUsed: "65622",
-    gasPrice: "10000000000",
-    inputData: "0x992bade87779dab573f067b70195ccb6c3",
-    nonce: "189",
-    transactionIndex: "9",
-    r: "0xfe73e69d48f46bca74fce2827863fce1d0bb3f7ae433c4a0c6b8c9c6e039abf0",
-    s: "0x7784f3cc4ba41a05c1012312ad2d2e688242701469c1cf46621883fe7dbad244",
-    v: "0x1b"
-  }) { hash }
-
-  l4_10_1: create_Log(input: {
-    address: "0x440d62c93fc27046d83d7d6a2ded80747275a44c",
-    topics: ["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", "0x35c7e8a55a5d88987dd3329771d800aff2aab1c5ff15b3408c7e53d5cc0646a9", "0x205abfe7e6bfab248e8222f6ce06d4bced335b9566001bc714584e7531f625e7"],
-    data: "0xb9b450f402e094f82d5fd6ca25aba200b2139844d56106d0e447a147068486ea63d403dc73ddcf907608b8820c3dc8e0099a03a3fd94d504933b0a",
-    transactionHash: "0x2826233390a275a3e099e1bd081ce39e620638bc8af44eaf81e8076e88e07737",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "9",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e4_10_1: create_Event(input: {
-    contractAddress: "0x440d62c93fc27046d83d7d6a2ded80747275a44c",
-    eventName: "Approval",
-    parameters: "{\"owner\":\"0xc925c920c075deb721bfc72120ca9d35a7c1c901\",\"spender\":\"0x8e9ce9c882e07c301ee02ef7fa9661e332e3d118\",\"value\":\"0\"}",
-    transactionHash: "0x2826233390a275a3e099e1bd081ce39e620638bc8af44eaf81e8076e88e07737",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "9",
-    logIndex: "0"
-  }) { eventName }
-
-  l4_10_2: create_Log(input: {
-    address: "0x0dd363a5ab57541a6ee97b819fc5a6b1323a5aad",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0xee5c172e80708b0f3d29457ba9b51abdeaef236e709aed4e8a32c0be13b55366", "0xcc1068ed2470f8c337f4e3ac176fb4bc387ec7100f7f998ae89831ec5d4ca979"],
-    data: "0xb3c087a6a1edbae7fad2cf9691f61e3eec36a00f6c5466a9076da4a15724ca65e7aa39e48164478ff29da17babbe1411d3f826d98b8fc353724f0da0e",
-    transactionHash: "0x2826233390a275a3e099e1bd081ce39e620638bc8af44eaf81e8076e88e07737",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "9",
-    logIndex: "1",
-    removed: "false"
-  }) { address }
-
-  e4_10_2: create_Event(input: {
-    contractAddress: "0x0dd363a5ab57541a6ee97b819fc5a6b1323a5aad",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0xc925c920c075deb721bfc72120ca9d35a7c1c901\",\"to\":\"0x8e9ce9c882e07c301ee02ef7fa9661e332e3d118\",\"value\":\"0\"}",
-    transactionHash: "0x2826233390a275a3e099e1bd081ce39e620638bc8af44eaf81e8076e88e07737",
-    blockHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    blockNumber: 20483213,
-    transactionIndex: "9",
-    logIndex: "1"
-  }) { eventName }
-
-  b5: create_Block(input: {
-    hash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    number: 20483214,
-    timestamp: "2023-07-01T12:08:00Z",
-    parentHash: "0x2281069f373f3ed13c4b1839eab0326ea7a530f5e0f4e17e3d3d03f446c8ff36",
-    difficulty: "1003900",
-    gasUsed: "5797152",
-    gasLimit: "30000000",
-    nonce: "0x7ee85e1a9afe541c",
-    miner: "0x2a351166891edf53c5267725c430a70f255d1144",
-    size: "1198",
-    stateRoot: "0x61e680144d84bf40aa95f3429f88e9c0957e3f8f528d2e5fa18b45dedeefa98a",
-    sha3Uncles: "0x45025d198ddba48fd0d0d8e48a5be6ee8ff80e08dafee1d24e494c144c2c83e0",
-    transactionsRoot: "0x0a6f2d1acc062cc9fb24e63584b7b82c02280e03f0cf3b51fe31f91977dbece4",
-    receiptsRoot: "0x9d21a22101f13fb050b14b9f5751205fbf8ea7dae985b4c85192c93b6e91b267",
-    extraData: "0xe7edcec3c0aaf2e91b9c288116ac591be88a0d658b7a4e33321b28dda7527bd3"
-  }) { hash }
-
-  t5_1: create_Transaction(input: {
-    hash: "0x8e92780346d0ad5ea268c7034899f7dbd32bdc4471e0da80a73c144e97716e5f",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    from: "0x2d599ebd6234260f5f1cd2a9bacc7bda92055a42",
-    to: "0x5cd1a8c9559e1a417275e256506dcd94efc4da5f",
-    value: "10",
-    gasUsed: "159722",
-    gasPrice: "30000000000",
-    inputData: "0x0740fe78e20d5778bbf7ad564ef118a6abf614e745be0958",
-    nonce: "10",
-    transactionIndex: "0",
-    r: "0x4aaa9d7ee1933df2bd9ce7cac0988df7655259abee00d578a85d81fd0a612417",
-    s: "0x7037f2c477bd1a2103b66e86ace04ef5e2acbdbe9bfaabb0aa7c42e39b927b5a",
-    v: "0x1b"
-  }) { hash }
-
-  l5_1_1: create_Log(input: {
-    address: "0xb41e52ca32529bf99a41614fc8e604916b752599",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0x56d79082521b5bfa109f82474a9d02236978bf266d5edd25f794334052627129", "0x91512cd9b563314266ac63e47dcf192f20623f91a037650788bd0f28fcb1feb4"],
-    data: "0xe472c63c06f221ae06c61dce00b8ccc7476e10f3a00f281d6756960caf99657ea0f54a4ba8ba363d06957df6f6c6470187d8eb9dd8df8",
-    transactionHash: "0x8e92780346d0ad5ea268c7034899f7dbd32bdc4471e0da80a73c144e97716e5f",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    transactionIndex: "0",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e5_1_1: create_Event(input: {
-    contractAddress: "0xb41e52ca32529bf99a41614fc8e604916b752599",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0x2d599ebd6234260f5f1cd2a9bacc7bda92055a42\",\"to\":\"0x5cd1a8c9559e1a417275e256506dcd94efc4da5f\",\"value\":\"10\"}",
-    transactionHash: "0x8e92780346d0ad5ea268c7034899f7dbd32bdc4471e0da80a73c144e97716e5f",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    transactionIndex: "0",
-    logIndex: "0"
-  }) { eventName }
-
-  l5_1_2: create_Log(input: {
-    address: "0x3c7f241c73eab5efc138b9033882be5396c22dc3",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0x9c06c225c0aaa8cb85c7c87fe280698a8abdd007022d44f47cf843e6c7b1ae06", "0x802db1326d8078886fe10d5faa395b89cda942fbd4fa5003d2e689e9a57a3d67"],
-    data: "0xd8f2112e0e349aec2718992957ab466f5fbcf3614dac8ef32a42e1820f33d329c88c2371eb959f6a57ff",
-    transactionHash: "0x8e92780346d0ad5ea268c7034899f7dbd32bdc4471e0da80a73c144e97716e5f",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    transactionIndex: "0",
-    logIndex: "1",
-    removed: "false"
-  }) { address }
-
-  e5_1_2: create_Event(input: {
-    contractAddress: "0x3c7f241c73eab5efc138b9033882be5396c22dc3",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0x2d599ebd6234260f5f1cd2a9bacc7bda92055a42\",\"to\":\"0x5cd1a8c9559e1a417275e256506dcd94efc4da5f\",\"value\":\"10\"}",
-    transactionHash: "0x8e92780346d0ad5ea268c7034899f7dbd32bdc4471e0da80a73c144e97716e5f",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    transactionIndex: "0",
-    logIndex: "1"
-  }) { eventName }
-
-  l5_1_3: create_Log(input: {
-    address: "0x9fe01f34a75a352055cf1dcd04db66be2d9c4300",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0xf00e17f1dd751f17884df9ed5db1f98acae4dfcb8253e8ffb0169a4415d5c716", "0x4c8b5be7701e81c7a2da448ecfb34a6f01b6cd664fd76844bc57e47f55a63177"],
-    data: "0x10946816e086676368bc24bf08e7e3b3fdc0c9bb9943bf7e5d90a64e6db684617ee662b0753bdbb204a0cddc1ce79fdf29d74b207a594fc543abc7e96d78",
-    transactionHash: "0x8e92780346d0ad5ea268c7034899f7dbd32bdc4471e0da80a73c144e97716e5f",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    transactionIndex: "0",
-    logIndex: "2",
-    removed: "false"
-  }) { address }
-
-  e5_1_3: create_Event(input: {
-    contractAddress: "0x9fe01f34a75a352055cf1dcd04db66be2d9c4300",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0x2d599ebd6234260f5f1cd2a9bacc7bda92055a42\",\"to\":\"0x5cd1a8c9559e1a417275e256506dcd94efc4da5f\",\"value\":\"10\"}",
-    transactionHash: "0x8e92780346d0ad5ea268c7034899f7dbd32bdc4471e0da80a73c144e97716e5f",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    transactionIndex: "0",
-    logIndex: "2"
-  }) { eventName }
-
-  t5_2: create_Transaction(input: {
-    hash: "0xa906ba9dbdb62f1f6114204e6cc75bce65569e862dc033109dc0e64d99e6fbb8",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    from: "0x2fd106f3d9b309bf78dd98f67e1a40acdb26e9ee",
-    to: "0x27e878b1ca61c5a1471c8c58797b8ca5353bc17e",
-    value: "1",
-    gasUsed: "22339",
-    gasPrice: "45000000000",
-    inputData: "0x6a9d9",
-    nonce: "97",
-    transactionIndex: "1",
-    r: "0xd0916fc8e8ed32d2553a17cabd21193a766b4dc037aa005af6030259be32b1c2",
-    s: "0x936cb1ba337de2df2f009465b0f3d24764268b5418116f2ffbbc4e80cc325d41",
-    v: "0x1b"
-  }) { hash }
-
-  t5_3: create_Transaction(input: {
-    hash: "0xcb2daf2533d1223477615abf41d4739ad30c3c19b0b522416d03c83088d12f38",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    from: "0x178da88b0c0a1d4e8acd7b1f84829409beed5a69",
-    to: "0xecc2b613c9f4c3f9ca04c4ec23cc4cd06948cdf1",
-    value: "1",
-    gasUsed: "124765",
-    gasPrice: "20000000000",
-    inputData: "0x5ff9152bf4624a4856a4ac10a9c2e53b1a40b7a62638bd0a",
-    nonce: "156",
-    transactionIndex: "2",
-    r: "0x794744302488738280f786ef491433d4726f2301c495dbed6abfe9b4d6946f4a",
-    s: "0x9954a6a32e50a178ab75f508ecfdcc14f9ae241fa626cb63b4c431f92887030c",
-    v: "0x1b"
-  }) { hash }
-
-  l5_3_1: create_Log(input: {
-    address: "0x9b4c9be98662f33b7778e5de020169799fbbd22f",
-    topics: ["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", "0x143b4f86ed74f916635557a81e09e6396ce9eff80e07ccdbc00ec45435436d5f", "0x8e4d866609bd51ccc18b7356886a8239db348530c7e2f097c832dabbb8527f63"],
-    data: "0xd6caf5fcedfffb6bd2692f82b7095df4660fc3b0132273a909956d8f528020c3c8e092af70cece7ce51c3156e5",
-    transactionHash: "0xcb2daf2533d1223477615abf41d4739ad30c3c19b0b522416d03c83088d12f38",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    transactionIndex: "2",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e5_3_1: create_Event(input: {
-    contractAddress: "0x9b4c9be98662f33b7778e5de020169799fbbd22f",
-    eventName: "Approval",
-    parameters: "{\"owner\":\"0x178da88b0c0a1d4e8acd7b1f84829409beed5a69\",\"spender\":\"0xecc2b613c9f4c3f9ca04c4ec23cc4cd06948cdf1\",\"value\":\"1\"}",
-    transactionHash: "0xcb2daf2533d1223477615abf41d4739ad30c3c19b0b522416d03c83088d12f38",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    transactionIndex: "2",
-    logIndex: "0"
-  }) { eventName }
-
-  t5_4: create_Transaction(input: {
-    hash: "0xd9751bce58bf3bbe65fe033a93ef65d0dadd21af6bcf966d88f15c64fcfdbc8a",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    from: "0xecc88e2bb78e8a1480b7ef508ca78a07eb81f0b7",
-    to: "0x66bc6537dc9180f7e6182b0c6580a314db7ed669",
-    value: "2500",
-    gasUsed: "143494",
-    gasPrice: "17000000000",
-    inputData: "0x8cd1764f6f83a41921205fd1f3a3c98eff6670d2886aeb8f6a0b5d",
-    nonce: "8",
-    transactionIndex: "3",
-    r: "0x5e0cfadf1f23557c36346fe8b9367fde0a0f21cb30d81f1e69e86078be6da909",
-    s: "0x84f51063e7c872dfa8881a60651ebd0a4d13b5614cc67057bcb8070e3b815e65",
-    v: "0x1b"
-  }) { hash }
-
-  t5_5: create_Transaction(input: {
-    hash: "0x4b62a00946241c4193171b99e6befe648aa73b25f464d84b3a5bbed2aa1713da",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    from: "0x98ec3a0993a0489d917a0edbbb6ba2144eea9eef",
-    to: "0xf8b5b9346e497ff10f19ab99de83dd46adf34ab7",
-    value: "1000",
-    gasUsed: "28830",
-    gasPrice: "12000000000",
-    inputData: "0xde80c9344f4fcb629b3683f11a9ba79bbabd53d66bfdd1b0920d1962f",
-    nonce: "22",
-    transactionIndex: "4",
-    r: "0xbafa52e77cc172d1b021bb6223b6515c911676d7f1507e52699e3dedc7840792",
-    s: "0x595cd9f84d9808e65fdd7ea2fe9859ce298c6a72aadc946804c0c8ccd2354474",
-    v: "0x1c"
-  }) { hash }
-
-  l5_5_1: create_Log(input: {
-    address: "0xf4517e67f81c26df9af718aacaecbec01ba24cfd",
-    topics: ["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", "0x886d75e1bd38db688511942de8e3b417a22b0adb377aa128655fdd65f1846630", "0xc12f11b4428be9db0a4f05bd3396a6190ffb371d20443ce9a6e39e7419724e97"],
-    data: "0x5dddbc1576c2dba0d48eaaa4de417cf14ea300bdf1d0ae22522ce657b6770b89a2daf1e9643",
-    transactionHash: "0x4b62a00946241c4193171b99e6befe648aa73b25f464d84b3a5bbed2aa1713da",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    transactionIndex: "4",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e5_5_1: create_Event(input: {
-    contractAddress: "0xf4517e67f81c26df9af718aacaecbec01ba24cfd",
-    eventName: "Approval",
-    parameters: "{\"owner\":\"0x98ec3a0993a0489d917a0edbbb6ba2144eea9eef\",\"spender\":\"0xf8b5b9346e497ff10f19ab99de83dd46adf34ab7\",\"value\":\"1000\"}",
-    transactionHash: "0x4b62a00946241c4193171b99e6befe648aa73b25f464d84b3a5bbed2aa1713da",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    transactionIndex: "4",
-    logIndex: "0"
-  }) { eventName }
-
-  l5_5_2: create_Log(input: {
-    address: "0x71485c8daa3041922a91a31769cb77d670afb96e",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0x093c87ee143e08e135a576f2ebc3eceb1b3f77021bb2c672f6c9f0891cb9b4a6", "0xbe0fcb08c50fad45e35d04c23d0307d02802e1164fc50beeff128e4c433adc9d"],
-    data: "0xfe6abc3541b36bc7e95b11fb3de8df6b343ff8e9fe7ba967bcf35b41261c8d34cf3",
-    transactionHash: "0x4b62a00946241c4193171b99e6befe648aa73b25f464d84b3a5bbed2aa1713da",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    transactionIndex: "4",
-    logIndex: "1",
-    removed: "false"
-  }) { address }
-
-  e5_5_2: create_Event(input: {
-    contractAddress: "0x71485c8daa3041922a91a31769cb77d670afb96e",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0x98ec3a0993a0489d917a0edbbb6ba2144eea9eef\",\"to\":\"0xf8b5b9346e497ff10f19ab99de83dd46adf34ab7\",\"value\":\"1000\"}",
-    transactionHash: "0x4b62a00946241c4193171b99e6befe648aa73b25f464d84b3a5bbed2aa1713da",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    transactionIndex: "4",
-    logIndex: "1"
-  }) { eventName }
-
-  t5_6: create_Transaction(input: {
-    hash: "0x2d66b71627f61ac4fb77aa5d5148f8f3355c69b3e754472eeda078eb1aafff2e",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    from: "0x9624969a6b722afb14e51816cbebd58663dce0aa",
-    to: "0x0c8788312094ff86b843032d3647bea69232af16",
-    value: "500",
-    gasUsed: "141076",
-    gasPrice: "20000000000",
-    inputData: "0x12d95c59aa9d50537a8c54790f2e7978cc1a8f11d1721eb3c6",
-    nonce: "86",
-    transactionIndex: "5",
-    r: "0x4282505593fac2c1ad82a83666dcb04a2ada3e3bf51a59552339583939026bc6",
-    s: "0x395da403503e914199dccb924e537cea3d983a64303361a463bc579580448c5c",
-    v: "0x1c"
-  }) { hash }
-
-  t5_7: create_Transaction(input: {
-    hash: "0x7504a7857de1efc0946fdcf91ff421ea5910761b20f49e4b85db92d65fd7a573",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    from: "0x56c65ed0f1857be72b722d526a79e1b0f0ffb099",
-    to: "0xc6becdd4270ab288b855baa3661a2b93d6b330df",
-    value: "500",
-    gasUsed: "110817",
-    gasPrice: "10000000000",
-    inputData: "0xd7cb0a082f7f44784dfe1656342e2",
-    nonce: "134",
-    transactionIndex: "6",
-    r: "0x7b9ea4325ead7f62296730c571da8007307d9b21142492802e148d2dfe6529f0",
-    s: "0x640869f86699431db2109c02093637abae941f447bde42fc2fefdfeb26fe2462",
-    v: "0x1b"
-  }) { hash }
-
-  l5_7_1: create_Log(input: {
-    address: "0xe518f718b38aad2e7830fc9173bfaa63a7c41b89",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0x75e2a80d7ade041e2b6e851bbba7a891edee54311e40809f2359c3ebf08309dd", "0xf2d884d499f18df2303ee0775ae19970e749cdf8161873ee48c59e0933612d97"],
-    data: "0x728bcb335eb2f10787e864bcf90a6c4a24632a8323040c0f37c611b452985de7b684ad33d3a984d28",
-    transactionHash: "0x7504a7857de1efc0946fdcf91ff421ea5910761b20f49e4b85db92d65fd7a573",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    transactionIndex: "6",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e5_7_1: create_Event(input: {
-    contractAddress: "0xe518f718b38aad2e7830fc9173bfaa63a7c41b89",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0x56c65ed0f1857be72b722d526a79e1b0f0ffb099\",\"to\":\"0xc6becdd4270ab288b855baa3661a2b93d6b330df\",\"value\":\"500\"}",
-    transactionHash: "0x7504a7857de1efc0946fdcf91ff421ea5910761b20f49e4b85db92d65fd7a573",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    transactionIndex: "6",
-    logIndex: "0"
-  }) { eventName }
-
-  l5_7_2: create_Log(input: {
-    address: "0xaa6ea4c4b138915646bb7b16a50a0fa1f2e6b894",
-    topics: ["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", "0x58ffff898c8719d911d0c4c9d4ebb6fe7b9c0343080e5b8b6d12d1748e0e4c4b", "0x3f963c164b1797884eb47d2f8d8a9bbe35e63f94e374480566c4fc3ed80818ca"],
-    data: "0x325c7230b04451f9ab54edff8566a867e64e6d52b3104c0fe52868cca6f2bbf730b5062e70b1f67ee734f6829a15eb04d001f450f2538b",
-    transactionHash: "0x7504a7857de1efc0946fdcf91ff421ea5910761b20f49e4b85db92d65fd7a573",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    transactionIndex: "6",
-    logIndex: "1",
-    removed: "false"
-  }) { address }
-
-  e5_7_2: create_Event(input: {
-    contractAddress: "0xaa6ea4c4b138915646bb7b16a50a0fa1f2e6b894",
-    eventName: "Approval",
-    parameters: "{\"owner\":\"0x56c65ed0f1857be72b722d526a79e1b0f0ffb099\",\"spender\":\"0xc6becdd4270ab288b855baa3661a2b93d6b330df\",\"value\":\"500\"}",
-    transactionHash: "0x7504a7857de1efc0946fdcf91ff421ea5910761b20f49e4b85db92d65fd7a573",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    transactionIndex: "6",
-    logIndex: "1"
-  }) { eventName }
-
-  t5_8: create_Transaction(input: {
-    hash: "0x57ad14762aeb3ebe065601d092ea0583701edfbfaaa0a39a19e57cd9c4e5da33",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    from: "0x941978a18c43fc869693dce81edbae8221cde4d9",
-    to: "0x2e7ea6ef125863d8b487e08e091f6cb2ebc5d417",
-    value: "10",
-    gasUsed: "144108",
-    gasPrice: "15000000000",
-    inputData: "0xf34bcf524700aeb3b7495acc000af6d1606827ca64a",
-    nonce: "111",
-    transactionIndex: "7",
-    r: "0x8ee0f1d10f8c3877e1182f996ce2c7ed52bff90a8bdd349f9285fb7283f5d685",
-    s: "0x2546753a00e3640988bdef2b83ecc09ad723c9becfecbfdcc8fc1b40a4d9aa52",
-    v: "0x1c"
-  }) { hash }
-
-  l5_8_1: create_Log(input: {
-    address: "0x19f4f4eb98450d2b1d5e7d811cf49dd617528716",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0x677023380cb8aafab49b4c3a286de8be6a2e6e27abcdd76bd82e4ac133d48d9f", "0xd56c94db3fe6df1204f21a406e5343b218bc598d5413cadd676b14964c4a7280"],
-    data: "0x1faa928514996b1f8b06751e0488096200ef357a74ff7fdba8ec2e4ebf7aa939e35cdd3a76485e142b1368771d5fa5",
-    transactionHash: "0x57ad14762aeb3ebe065601d092ea0583701edfbfaaa0a39a19e57cd9c4e5da33",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    transactionIndex: "7",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e5_8_1: create_Event(input: {
-    contractAddress: "0x19f4f4eb98450d2b1d5e7d811cf49dd617528716",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0x941978a18c43fc869693dce81edbae8221cde4d9\",\"to\":\"0x2e7ea6ef125863d8b487e08e091f6cb2ebc5d417\",\"value\":\"10\"}",
-    transactionHash: "0x57ad14762aeb3ebe065601d092ea0583701edfbfaaa0a39a19e57cd9c4e5da33",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    transactionIndex: "7",
-    logIndex: "0"
-  }) { eventName }
-
-  t5_9: create_Transaction(input: {
-    hash: "0x9ef662417e334eb7bae29522d551ca210886c86c89865d284501e45ec7a5e1ea",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    from: "0xf3166b610111d64adfea9cbd3f59e0798d6759cb",
-    to: "0xd92a9d6a3eaf6a2b3fccbbdad0177ea45c884205",
-    value: "10",
-    gasUsed: "54523",
-    gasPrice: "20000000000",
-    inputData: "0x8abfb6e47fc",
-    nonce: "105",
-    transactionIndex: "8",
-    r: "0x18294d9615f127f454306b49645b129c480eda61e69fce01e499cdcc97d096d5",
-    s: "0xb0aa5ad5f5cc464ae5f79d5f18e56788ddc31b39c21cc5cf588807b2dad27981",
-    v: "0x1b"
-  }) { hash }
-
-  l5_9_1: create_Log(input: {
-    address: "0x73703c68fd246ff7025502c63b500473b46267c6",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0x90525f1573df5135b073efac00032eca6599786f3b2a9f9d33e1e04f45181170", "0x6935653c00b658274b5ec5b4152733deb9565cf032ce33ded405a3a6c85de705"],
-    data: "0x192fa6090b62821a0eaa08a59dfe17f8def1070ec891a7aa02f5e5ee74503740b3252680d6c021b0591ca",
-    transactionHash: "0x9ef662417e334eb7bae29522d551ca210886c86c89865d284501e45ec7a5e1ea",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    transactionIndex: "8",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e5_9_1: create_Event(input: {
-    contractAddress: "0x73703c68fd246ff7025502c63b500473b46267c6",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0xf3166b610111d64adfea9cbd3f59e0798d6759cb\",\"to\":\"0xd92a9d6a3eaf6a2b3fccbbdad0177ea45c884205\",\"value\":\"10\"}",
-    transactionHash: "0x9ef662417e334eb7bae29522d551ca210886c86c89865d284501e45ec7a5e1ea",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    transactionIndex: "8",
-    logIndex: "0"
-  }) { eventName }
-
-  l5_9_2: create_Log(input: {
-    address: "0x22f8f22e1c8bedc62581e0992731338adfceed2a",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0x8c03f143ed9a2fe144608b79e5ee4a641b58f7bf5e566af05807cd69c9984e77", "0xacb472dec54f7a7790c513dd67813842bc68a5d6c5d566be1988bb396894223e"],
-    data: "0x889af952959c73b2533d8f58c95e58e6a6fb3b701ea38b278f571ae58a620248c97fc596128d0ddc30cd7e9342f1ca0d28e2b0335a0",
-    transactionHash: "0x9ef662417e334eb7bae29522d551ca210886c86c89865d284501e45ec7a5e1ea",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    transactionIndex: "8",
-    logIndex: "1",
-    removed: "false"
-  }) { address }
-
-  e5_9_2: create_Event(input: {
-    contractAddress: "0x22f8f22e1c8bedc62581e0992731338adfceed2a",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0xf3166b610111d64adfea9cbd3f59e0798d6759cb\",\"to\":\"0xd92a9d6a3eaf6a2b3fccbbdad0177ea45c884205\",\"value\":\"10\"}",
-    transactionHash: "0x9ef662417e334eb7bae29522d551ca210886c86c89865d284501e45ec7a5e1ea",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    transactionIndex: "8",
-    logIndex: "1"
-  }) { eventName }
-
-  l5_9_3: create_Log(input: {
-    address: "0x462d10815f5d74351c2894b1ecce85112928848c",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0xf7f57d2bb5a8eafd6f570aafff6ced0f931b683a08717ad04bdcd0d6b9ec0fa2", "0x521294c54c993048b91b7acb7a587fea1edbae7f8b4a255a9de12fa55f58da56"],
-    data: "0xf81417a81e0182a2494dafa7a26fc7a59d294d5081b40c768d22ff6e45cb661932f2c17671b99297dd150627f15217dfdfeee7daec9bb9a168",
-    transactionHash: "0x9ef662417e334eb7bae29522d551ca210886c86c89865d284501e45ec7a5e1ea",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    transactionIndex: "8",
-    logIndex: "2",
-    removed: "false"
-  }) { address }
-
-  e5_9_3: create_Event(input: {
-    contractAddress: "0x462d10815f5d74351c2894b1ecce85112928848c",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0xf3166b610111d64adfea9cbd3f59e0798d6759cb\",\"to\":\"0xd92a9d6a3eaf6a2b3fccbbdad0177ea45c884205\",\"value\":\"10\"}",
-    transactionHash: "0x9ef662417e334eb7bae29522d551ca210886c86c89865d284501e45ec7a5e1ea",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    transactionIndex: "8",
-    logIndex: "2"
-  }) { eventName }
-
-  t5_10: create_Transaction(input: {
-    hash: "0x3a86b3314c6ab671467626b29aa0e04c80d4d0ce93a399fd53d9784ee71591da",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    from: "0xf5b5157b6ee35b5829b2ca28ac99d8a470082b59",
-    to: "0x4cfba8f02ffb139ce17df4a140192ef1f78d173d",
-    value: "1",
-    gasUsed: "79080",
-    gasPrice: "17000000000",
-    inputData: "0xf",
-    nonce: "150",
-    transactionIndex: "9",
-    r: "0x42c8bfa5fb9564cfa2b1dc2bbe3abdd2dd917d7c8d0aba3d3276ad6548b24bcc",
-    s: "0x2424de9cf9fd62d71b5f186c55b2d847034f9c03fc632d7e0bb7c0d4560d6bdf",
-    v: "0x1b"
-  }) { hash }
-
-  l5_10_1: create_Log(input: {
-    address: "0xbfebc9592090165f606495e9c6a47ad234070dad",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0x2a623352ef06cdcc7c9f5275da8a066f15807fb6b63648a4eade3a171bce1e24", "0xca4992b57502a38eefd827c2dbedb454c3a80498968aefdc27daa012bbce646b"],
-    data: "0xc03924e0dc3a7d1f1e4040763250dcfd7e506e7987cbdf0e30bcaf96dff1a8ce672c80a8df71bd315a6345dd",
-    transactionHash: "0x3a86b3314c6ab671467626b29aa0e04c80d4d0ce93a399fd53d9784ee71591da",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    transactionIndex: "9",
-    logIndex: "0",
-    removed: "false"
-  }) { address }
-
-  e5_10_1: create_Event(input: {
-    contractAddress: "0xbfebc9592090165f606495e9c6a47ad234070dad",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0xf5b5157b6ee35b5829b2ca28ac99d8a470082b59\",\"to\":\"0x4cfba8f02ffb139ce17df4a140192ef1f78d173d\",\"value\":\"1\"}",
-    transactionHash: "0x3a86b3314c6ab671467626b29aa0e04c80d4d0ce93a399fd53d9784ee71591da",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    transactionIndex: "9",
-    logIndex: "0"
-  }) { eventName }
-
-  l5_10_2: create_Log(input: {
-    address: "0x4a8f11a19029c3ae010211e6a8ce79f97c718363",
-    topics: ["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", "0xcf274360b9485b23216b9095925ae1747edecd1c5a26906f6e996036d756e05c", "0xc750f3b92a37732fd1aeecef2441714eae81b5706d0ceff358f5caae26c9df8b"],
-    data: "0x9a7eb5be994a4d13b333adf77b2aed9df1b1d066278da15fad179bc676479b48ae1a2aaf4c60",
-    transactionHash: "0x3a86b3314c6ab671467626b29aa0e04c80d4d0ce93a399fd53d9784ee71591da",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    transactionIndex: "9",
-    logIndex: "1",
-    removed: "false"
-  }) { address }
-
-  e5_10_2: create_Event(input: {
-    contractAddress: "0x4a8f11a19029c3ae010211e6a8ce79f97c718363",
-    eventName: "Approval",
-    parameters: "{\"owner\":\"0xf5b5157b6ee35b5829b2ca28ac99d8a470082b59\",\"spender\":\"0x4cfba8f02ffb139ce17df4a140192ef1f78d173d\",\"value\":\"1\"}",
-    transactionHash: "0x3a86b3314c6ab671467626b29aa0e04c80d4d0ce93a399fd53d9784ee71591da",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    transactionIndex: "9",
-    logIndex: "1"
-  }) { eventName }
-
-  l5_10_3: create_Log(input: {
-    address: "0x6584e2c3c5ce8fd56f06b8fe5d36345825740c5b",
-    topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0x83b8ab825a728017bc70654df6a909ecbe3dd4264b1d5dac969ec15605be59ce", "0x6c62c6709c13f5c4076c919f922d78717313cd7cd548ba9290aec45b2309d21c"],
-    data: "0x115c09d03e8a63c49820dcf9af742db158466b880e220e5b0570b0dde38a7763f28eab8255955052b51b43ec035dd5a1a1f7482797175b15f8c47",
-    transactionHash: "0x3a86b3314c6ab671467626b29aa0e04c80d4d0ce93a399fd53d9784ee71591da",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    transactionIndex: "9",
-    logIndex: "2",
-    removed: "false"
-  }) { address }
-
-  e5_10_3: create_Event(input: {
-    contractAddress: "0x6584e2c3c5ce8fd56f06b8fe5d36345825740c5b",
-    eventName: "Transfer",
-    parameters: "{\"from\":\"0xf5b5157b6ee35b5829b2ca28ac99d8a470082b59\",\"to\":\"0x4cfba8f02ffb139ce17df4a140192ef1f78d173d\",\"value\":\"1\"}",
-    transactionHash: "0x3a86b3314c6ab671467626b29aa0e04c80d4d0ce93a399fd53d9784ee71591da",
-    blockHash: "0xc345470bc99db708bbaaa14d6ad0fff9674fd618d1057cc4d05541eba0c3e1de",
-    blockNumber: 20483214,
-    transactionIndex: "9",
-    logIndex: "2"
-  }) { eventName }
-
+}`
+
+type mockLog struct {
+	alias            string
+	address          string
+	topics           []string
+	data             string
+	transactionHash  string
+	blockHash        string
+	blockNumber      int
+	transactionIndex int
+	logIndex         int
 }
-`
+
+var mockLogs = []mockLog{
+	{
+		alias:   "l1_1_1",
+		address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+		topics:  []string{"0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0x000000000000000000000000DFd5293D8e347dFe59E90eFd55b2956a1343963d", "0x00000000000000000000000028C6c06298d514Db089934071355E5743bf21d60"},
+		data:             "0x00000000000000000000000000000000000000000000000000000000003d0900",
+		transactionHash:  "0xaa1c8b56e2f34d79e0b1a2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3",
+		blockHash:        "0x4e3a3754410177e6937ef1f84bba68ea139e8d1a2258c5f85db9f1cd715a1bdd",
+		blockNumber:      18500000,
+		transactionIndex: 0,
+		logIndex:         0,
+	},
+	{
+		alias:   "l1_2_1",
+		address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+		topics:  []string{"0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0x00000000000000000000000028C6c06298d514Db089934071355E5743bf21d60", "0x000000000000000000000000d8dA6BF26964aF9D7eEd9e03E53415D37aA96045"},
+		data:             "0x000000000000000000000000000000000000000000000000000000174876e800",
+		transactionHash:  "0xbb2d9c67f3e45a80f1c2b3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4",
+		blockHash:        "0x4e3a3754410177e6937ef1f84bba68ea139e8d1a2258c5f85db9f1cd715a1bdd",
+		blockNumber:      18500000,
+		transactionIndex: 1,
+		logIndex:         1,
+	},
+	{
+		alias:   "l1_3_1",
+		address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+		topics:  []string{"0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", "0x00000000000000000000000047ac0Fb4F2D84898e4D9E7b4DaB3C24507a6D503", "0x000000000000000000000000E592427A0AEce92De3Edee1F18E0157C05861564"},
+		data:             "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+		transactionHash:  "0xcc3eab78a4f56b91a2d3c4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5",
+		blockHash:        "0x4e3a3754410177e6937ef1f84bba68ea139e8d1a2258c5f85db9f1cd715a1bdd",
+		blockNumber:      18500000,
+		transactionIndex: 2,
+		logIndex:         2,
+	},
+	{
+		alias:   "l1_4_1",
+		address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+		topics:  []string{"0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0x00000000000000000000000056Eddb7aa87536c09CCc2793473599fD21A8b17F", "0x000000000000000000000000Dac17F958D2ee523a2206206994597C13D831ec7"},
+		data:             "0x0000000000000000000000000000000000000000000000000000000005f5e100",
+		transactionHash:  "0xdd4fbc89b5a67ca2b3e4d5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6",
+		blockHash:        "0x4e3a3754410177e6937ef1f84bba68ea139e8d1a2258c5f85db9f1cd715a1bdd",
+		blockNumber:      18500000,
+		transactionIndex: 3,
+		logIndex:         3,
+	},
+	{
+		alias:   "l1_5_1",
+		address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+		topics:  []string{"0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0x00000000000000000000000021a31Ee1afC51d94C2eFcCAa2092aD1028285549", "0x000000000000000000000000BE0eB53F46cd790Cd13851d5EFf43D12404d33E8"},
+		data:             "0x0000000000000000000000000000000000000000000000000000001caab5c3b3",
+		transactionHash:  "0xee5acd9ac6b78db3c4f5e6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7",
+		blockHash:        "0x4e3a3754410177e6937ef1f84bba68ea139e8d1a2258c5f85db9f1cd715a1bdd",
+		blockNumber:      18500000,
+		transactionIndex: 4,
+		logIndex:         4,
+	},
+	{
+		alias:   "l1_6_1",
+		address: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+		topics:  []string{"0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0x000000000000000000000000DFd5293D8e347dFe59E90eFd55b2956a1343963d", "0x00000000000000000000000028C6c06298d514Db089934071355E5743bf21d60"},
+		data:             "0x0000000000000000000000000000000000000000000000000000000005f5e100",
+		transactionHash:  "0xab01usdt1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d",
+		blockHash:        "0x4e3a3754410177e6937ef1f84bba68ea139e8d1a2258c5f85db9f1cd715a1bdd",
+		blockNumber:      18500000,
+		transactionIndex: 5,
+		logIndex:         5,
+	},
+	{
+		alias:   "l1_7_1",
+		address: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+		topics:  []string{"0xe1fffcc4923d04b559f4d29a8bfc6cda04eb5b0d3c460751c2402c5c5cc9109c", "0x00000000000000000000000028C6c06298d514Db089934071355E5743bf21d60"},
+		data:             "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000",
+		transactionHash:  "0xcd02weth2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e",
+		blockHash:        "0x4e3a3754410177e6937ef1f84bba68ea139e8d1a2258c5f85db9f1cd715a1bdd",
+		blockNumber:      18500000,
+		transactionIndex: 6,
+		logIndex:         6,
+	},
+	{
+		alias:   "l2_1_1",
+		address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+		topics:  []string{"0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0x000000000000000000000000BE0eB53F46cd790Cd13851d5EFf43D12404d33E8", "0x0000000000000000000000005041ed759Dd4aFc3a72b8192C143F72f4724081A"},
+		data:             "0x00000000000000000000000000000000000000000000000000000002540be400",
+		transactionHash:  "0xff6bde0ab7c89ec4d5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8",
+		blockHash:        "0x5f4b4865521288f7a48ef2f95bba69ea239f9d2b3369d6f96eb9f2de826b2cee",
+		blockNumber:      18500001,
+		transactionIndex: 0,
+		logIndex:         0,
+	},
+	{
+		alias:   "l2_2_1",
+		address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+		topics:  []string{"0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0x0000000000000000000000003fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD", "0x000000000000000000000000F977814e90dA44bFA03b6295A0616a897441aceC"},
+		data:             "0x000000000000000000000000000000000000000000000000000000003b9aca00",
+		transactionHash:  "0x007cef1bc8d9afd5e6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9",
+		blockHash:        "0x5f4b4865521288f7a48ef2f95bba69ea239f9d2b3369d6f96eb9f2de826b2cee",
+		blockNumber:      18500001,
+		transactionIndex: 1,
+		logIndex:         1,
+	},
+	{
+		alias:   "l2_3_1",
+		address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+		topics:  []string{"0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", "0x000000000000000000000000F977814e90dA44bFA03b6295A0616a897441aceC", "0x00000000000000000000000068b3465833fb72A70ecDF485E0e4C7bD8665Fc45"},
+		data:             "0x00000000000000000000000000000000000000000000000000000000ee6b2800",
+		transactionHash:  "0x118def2cd9eabae6f7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9fa",
+		blockHash:        "0x5f4b4865521288f7a48ef2f95bba69ea239f9d2b3369d6f96eb9f2de826b2cee",
+		blockNumber:      18500001,
+		transactionIndex: 2,
+		logIndex:         2,
+	},
+	{
+		alias:   "l2_4_1",
+		address: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+		topics:  []string{"0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0x000000000000000000000000BE0eB53F46cd790Cd13851d5EFf43D12404d33E8", "0x000000000000000000000000d8dA6BF26964aF9D7eEd9e03E53415D37aA96045"},
+		data:             "0x0000000000000000000000000000000000000000000000056bc75e2d63100000",
+		transactionHash:  "0xef03dai03c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f",
+		blockHash:        "0x5f4b4865521288f7a48ef2f95bba69ea239f9d2b3369d6f96eb9f2de826b2cee",
+		blockNumber:      18500001,
+		transactionIndex: 3,
+		logIndex:         3,
+	},
+	{
+		alias:   "l2_5_1",
+		address: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+		topics:  []string{"0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0x0000000000000000000000003fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD", "0x000000000000000000000000F977814e90dA44bFA03b6295A0616a897441aceC"},
+		data:             "0x00000000000000000000000000000000000000000000000029a2241af62c0000",
+		transactionHash:  "0xa104weth4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a",
+		blockHash:        "0x5f4b4865521288f7a48ef2f95bba69ea239f9d2b3369d6f96eb9f2de826b2cee",
+		blockNumber:      18500001,
+		transactionIndex: 4,
+		logIndex:         4,
+	},
+	{
+		alias:   "l3_1_1",
+		address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+		topics:  []string{"0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0x000000000000000000000000d8dA6BF26964aF9D7eEd9e03E53415D37aA96045", "0x000000000000000000000000DFd5293D8e347dFe59E90eFd55b2956a1343963d"},
+		data:             "0x0000000000000000000000000000000000000000000000000000000000989680",
+		transactionHash:  "0x229ef03dea0bcbf7a8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9fa0b",
+		blockHash:        "0x6a5c5976632399a8b59f3fa6ccb7aefb34af0e3c4480e7fa7fc0a3ef937c3dff",
+		blockNumber:      18500002,
+		transactionIndex: 0,
+		logIndex:         0,
+	},
+	{
+		alias:   "l3_2_1",
+		address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+		topics:  []string{"0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0x0000000000000000000000005041ed759Dd4aFc3a72b8192C143F72f4724081A", "0x00000000000000000000000047ac0Fb4F2D84898e4D9E7b4DaB3C24507a6D503"},
+		data:             "0x000000000000000000000000000000000000000000000000000000012a05f200",
+		transactionHash:  "0x33af014efb1cdca8b9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9fa0b1c",
+		blockHash:        "0x6a5c5976632399a8b59f3fa6ccb7aefb34af0e3c4480e7fa7fc0a3ef937c3dff",
+		blockNumber:      18500002,
+		transactionIndex: 1,
+		logIndex:         1,
+	},
+	{
+		alias:   "l3_3_1",
+		address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+		topics:  []string{"0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0x000000000000000000000000E592427A0AEce92De3Edee1F18E0157C05861564", "0x00000000000000000000000056Eddb7aa87536c09CCc2793473599fD21A8b17F"},
+		data:             "0x0000000000000000000000000000000000000000000000000000000077359400",
+		transactionHash:  "0x44b0125fac2eddb9c0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9fa0b1c2d",
+		blockHash:        "0x6a5c5976632399a8b59f3fa6ccb7aefb34af0e3c4480e7fa7fc0a3ef937c3dff",
+		blockNumber:      18500002,
+		transactionIndex: 2,
+		logIndex:         2,
+	},
+	{
+		alias:   "l3_4_1",
+		address: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+		topics:  []string{"0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", "0x00000000000000000000000047ac0Fb4F2D84898e4D9E7b4DaB3C24507a6D503", "0x000000000000000000000000E592427A0AEce92De3Edee1F18E0157C05861564"},
+		data:             "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+		transactionHash:  "0xb205usdt5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b",
+		blockHash:        "0x6a5c5976632399a8b59f3fa6ccb7aefb34af0e3c4480e7fa7fc0a3ef937c3dff",
+		blockNumber:      18500002,
+		transactionIndex: 3,
+		logIndex:         3,
+	},
+	{
+		alias:   "l3_5_1",
+		address: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+		topics:  []string{"0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", "0x000000000000000000000000d8dA6BF26964aF9D7eEd9e03E53415D37aA96045", "0x00000000000000000000000068b3465833fb72A70ecDF485E0e4C7bD8665Fc45"},
+		data:             "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+		transactionHash:  "0xc306dai06f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c",
+		blockHash:        "0x6a5c5976632399a8b59f3fa6ccb7aefb34af0e3c4480e7fa7fc0a3ef937c3dff",
+		blockNumber:      18500002,
+		transactionIndex: 4,
+		logIndex:         4,
+	},
+}
+
+func BuildLogsMutation(blockDocIDs, txDocIDs map[string]string) string {
+	var sb strings.Builder
+	sb.WriteString("mutation {\n")
+	for _, log := range mockLogs {
+		quotedTopics := make([]string, len(log.topics))
+		for i, t := range log.topics {
+			quotedTopics[i] = fmt.Sprintf("%q", t)
+		}
+		topicsStr := "[" + strings.Join(quotedTopics, ", ") + "]"
+
+		txDocID := txDocIDs[log.transactionHash]
+		blockDocID := blockDocIDs[log.blockHash]
+
+		sb.WriteString(fmt.Sprintf(
+			"  %s: add_Ethereum__Mainnet__Log(input: {\n"+
+				"    address: %q,\n"+
+				"    topics: %s,\n"+
+				"    data: %q,\n"+
+				"    transactionHash: %q,\n"+
+				"    blockHash: %q,\n"+
+				"    blockNumber: %d,\n"+
+				"    transactionIndex: %d,\n"+
+				"    logIndex: %d,\n"+
+				"    removed: \"false\",\n"+
+				"    transaction: %q,\n"+
+				"    block: %q\n"+
+				"  }) { address }\n\n",
+			log.alias, log.address, topicsStr, log.data,
+			log.transactionHash, log.blockHash,
+			log.blockNumber, log.transactionIndex, log.logIndex,
+			txDocID, blockDocID,
+		))
+	}
+	sb.WriteString("}")
+	return sb.String()
+}

--- a/core/service/view.go
+++ b/core/service/view.go
@@ -91,7 +91,7 @@ func ClearQuery(name string, s viewstore.ViewStore) (models.View, error) {
 	return s.Save(name, view)
 }
 
-func InitLens(name string, label string, path string, args map[string]string, s viewstore.ViewStore) (models.View, error) {
+func InitLens(name string, label string, path string, args map[string]any, s viewstore.ViewStore) (models.View, error) {
 	view, err := s.Load(name)
 	if err != nil {
 		return models.View{}, err

--- a/core/service/view_test.go
+++ b/core/service/view_test.go
@@ -104,7 +104,7 @@ func TestViewService_LensLifecycle(t *testing.T) {
 		t.Fatalf("failed to write valid wasm file: %v", err)
 	}
 
-	view, err := service.InitLens(name, "testlens", wasmPath, map[string]string{"arg": "val"}, viewStore)
+	view, err := service.InitLens(name, "testlens", wasmPath, map[string]any{"arg": "val"}, viewStore)
 	if err != nil {
 		t.Fatalf("InitLens failed: %v", err)
 	}

--- a/tools/schema.graphql
+++ b/tools/schema.graphql
@@ -1,14 +1,16 @@
 directive @index(unique: Boolean) on FIELD_DEFINITION | OBJECT
 directive @relation(name: String) on FIELD_DEFINITION
 
-type Block {
+type Ethereum__Mainnet__Block {
     hash: String @index(unique: true)
     number: Int @index
     timestamp: String
     parentHash: String
     difficulty: String
+    totalDifficulty: String
     gasUsed: String
     gasLimit: String
+    baseFeePerGas: String
     nonce: String
     miner: String
     size: String
@@ -16,56 +18,97 @@ type Block {
     sha3Uncles: String
     transactionsRoot: String
     receiptsRoot: String
+    logsBloom: String
     extraData: String
+    mixHash: String
+    uncles: [String]
     # Relationships
-    transactions: [Transaction] @relation(name: "block_transactions")
+    transactions: [Ethereum__Mainnet__Transaction] @relation(name: "block_transactions")
 }
 
-type Transaction {
-    hash: String @index(unique: true)
-    blockHash: String @index
+# BlockSignature covers all documents in a block (txs, logs, ALEs, and the block itself)
+type Ethereum__Mainnet__BlockSignature {
     blockNumber: Int @index
+    blockHash: String
+    merkleRoot: String
+    cidCount: Int
+    cids: [String]
+    signatureType: String
+    signatureIdentity: String
+    signatureValue: String
+    createdAt: String
+}
+
+# SnapshotSignature seals a snapshot file with a Merkle root over per-block
+# signature Merkle roots. Used for cross-indexer attestation and snapshot exchange.
+type Ethereum__Mainnet__SnapshotSignature {
+    startBlock: Int
+    endBlock: Int
+    merkleRoot: String
+    blockCount: Int
+    signatureType: String
+    signatureIdentity: String
+    signatureValue: String
+    snapshotFile: String
+    createdAt: String
+    blockSigMerkleRoots: [String]
+}
+
+type Ethereum__Mainnet__Transaction {
+    hash: String @index(unique: true)
+    blockHash: String
+    blockNumber: Int
     from: String
     to: String
     value: String
-    gasUsed: String
+    gas: String
     gasPrice: String
-    inputData: String
+    gasUsed: String
+    maxFeePerGas: String
+    maxPriorityFeePerGas: String
+    input: String
     nonce: String
-    transactionIndex: String
+    transactionIndex: Int
+    type: String
+    chainId: String
+    v: String
     r: String
     s: String
-    v: String
+    status: Boolean
+    cumulativeGasUsed: String
+    effectiveGasPrice: String
     # Relationships
-    block: Block @relation(name: "block_transactions")
-    logs: [Log] @relation(name: "transaction_logs")
+    block: Ethereum__Mainnet__Block @index @relation(name: "block_transactions")
+    logs: [Ethereum__Mainnet__Log] @relation(name: "transaction_logs")
+    accessList: [Ethereum__Mainnet__AccessListEntry] @relation(name: "transaction_accessList")
 }
 
-type Log {
+type Ethereum__Mainnet__AccessListEntry {
+    address: String
+    blockNumber: Int
+    storageKeys: [String]
+    transaction: Ethereum__Mainnet__Transaction @index @relation(name: "transaction_accessList")
+}
+
+type Ethereum__Mainnet__Log {
     address: String
     topics: [String]
     data: String
     transactionHash: String
     blockHash: String
-    blockNumber: Int @index
-    transactionIndex: String
-    logIndex: String
+    blockNumber: Int
+    transactionIndex: Int
+    logIndex: Int
     removed: String
     # Relationships
-    block: Block @index @relation(name: "block_transactions")
-    transaction: Transaction @index @relation(name: "transaction_logs")
-    events: [Event] @relation(name: "log_events")
+    block: Ethereum__Mainnet__Block @index @relation(name: "block_logs")
+    transaction: Ethereum__Mainnet__Transaction @index @relation(name: "transaction_logs")
 }
 
-type Event {
-    contractAddress: String
-    eventName: String
-    parameters: String
-    transactionHash: String @index
-    blockHash: String
-    blockNumber: Int @index
-    transactionIndex: String
-    logIndex: String
-    # Relationships
-    log: Log @index @relation(name: "log_events")
+type Ethereum__Mainnet__AttestationRecord {
+    attested_doc: String @index
+    source_doc: String
+    CIDs: [String]
+    doc_type: String @index
+    vote_count: Int @crdt(type: pcounter)
 }

--- a/tools/schema.graphql
+++ b/tools/schema.graphql
@@ -1,5 +1,6 @@
 directive @index(unique: Boolean) on FIELD_DEFINITION | OBJECT
 directive @relation(name: String) on FIELD_DEFINITION
+directive @crdt(type: String) on FIELD_DEFINITION
 
 type Ethereum__Mainnet__Block {
     hash: String @index(unique: true)


### PR DESCRIPTION
New CLI commands:

view list — lists all locally saved views from ~/.shinzo/views/ in a table (name, source collection, lens count)

view deploy --target playground — deploys a view into an already-running local DefraDB instance without starting a new one; accepts --url flag (default http://127.0.0.1:9181)

playground — starts a local DefraDB node with schema + mock data only, no view deployed, for manual exploration
core/service/defra.go