### PR TITLE
feat: implement an example lens in AssemblyScript

### DIFF
--- a/as/.gitignore
+++ b/as/.gitignore
@@ -1,0 +1,47 @@
+# Binaries and build outputs
+/build/
+/dist/
+/bin/
+*.exe
+*.dll
+*.so
+*.dylib
+*.test
+
+# Go artifacts
+*.out
+coverage.*
+*.coverprofile
+*.prof
+*.pprof
+
+# Dependencies (if vendored)
+/vendor/
+
+# IDE/editor
+.vscode/
+.idea/
+*.code-workspace
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Environment/secrets
+.env
+.env.*
+*.local
+
+# Logs & temp
+*.log
+*.tmp
+*.swp
+
+# Node (if you have frontend/tools)
+node_modules/
+
+# AssemblyScript build outputs
+as/build/
+
+# Misc
+.git-credentials

--- a/as/README.md
+++ b/as/README.md
@@ -1,0 +1,119 @@
+# Shinzo Lenses — AssemblyScript
+
+AssemblyScript [LensVM](https://docs.source.network/lensvm) lenses for the [Shinzo](https://github.com/shinzonetwork) indexing infrastructure. Each lens is a WASM module that transforms blockchain data inside the LensVM runtime.
+
+## Prerequisites
+
+- [Bun](https://bun.sh/) >= 1.0
+- Node.js >= 18 (used by AssemblyScript compiler)
+
+## Setup
+
+```bash
+cd as
+bun install
+```
+
+## Build
+
+```bash
+# Build all lenses
+bun run build
+
+# Build a specific lens
+bun run build:decode_log
+
+# Build with debug output (includes WAT + source maps)
+bun run build:decode_log:debug
+```
+
+Output goes to `build/<lens_name>/`.
+
+Then, a WASM file from the `build` directory can be used with a `viewkit` CLI to deplo
+
+## Test
+
+```bash
+bun test
+```
+
+Tests live alongside their lens in each lens directory (e.g. `decode_log/decode_log.test.ts`).
+
+## Adding a new lens
+
+1. **Create a directory** for the lens:
+
+   ```bash
+   mkdir -p my_lens/types
+   ```
+
+2. **Add an entry point** at `my_lens/index.ts`. It must export the LensVM interface:
+
+   ```ts
+   import { fromTransportVec, toTransportVec, nilPtr, JSON_TYPE_ID, EOS_TYPE_ID, ERROR_TYPE_ID } from "../lib/transport";
+
+   @external("lens", "next")
+   declare function next(): usize;
+
+   function abort(message: string | null, fileName: string | null, lineNumber: u32, columnNumber: u32): void {
+     unreachable();
+   }
+
+   export function alloc(size: usize): usize {
+     return heap.alloc(size);
+   }
+
+   export function set_param(ptr: usize): usize {
+     // Parse params, return nilPtr() on success
+     return nilPtr();
+   }
+
+   export function transform(): usize {
+     const ptr = next();
+     const msg = fromTransportVec(ptr);
+     if (msg.isEndOfStream) {
+       heap.free(ptr);
+       return toTransportVec(EOS_TYPE_ID, "");
+     }
+     // Transform msg.payload and return result
+     heap.free(ptr);
+     return toTransportVec(JSON_TYPE_ID, result);
+   }
+   ```
+
+3. **Add build targets** in `asconfig.json`:
+
+   ```json
+   {
+     "targets": {
+       "my_lens": {
+         "outFile": "build/my_lens/my_lens.wasm",
+         "textFile": "build/my_lens/my_lens.wat",
+         "sourceMap": true,
+         "optimizeLevel": 3,
+         "shrinkLevel": 0,
+         "use": ["abort=my_lens/index/abort"]
+       }
+     }
+   }
+   ```
+
+4. **Add build scripts** in `package.json`:
+
+   ```json
+   {
+     "scripts": {
+       "build": "bun run build:decode_log && bun run build:my_lens",
+       "build:my_lens": "asc my_lens/index.ts --target my_lens"
+     }
+   }
+   ```
+
+5. **Add tests** at `my_lens/my_lens.test.ts`.
+
+## References
+
+- [LensVM documentation](https://docs.source.network/lensvm)
+- [AssemblyScript](https://www.assemblyscript.org/)
+- [assemblyscript-json](https://github.com/aspect-build/assemblyscript-json)
+- [Source Network](https://source.network/)

--- a/as/asconfig.json
+++ b/as/asconfig.json
@@ -1,0 +1,24 @@
+{
+  "options": {
+    "path": ["node_modules"]
+  },
+  "targets": {
+    "decode_log_debug": {
+      "outFile": "build/decode_log/debug.wasm",
+      "textFile": "build/decode_log/debug.wat",
+      "sourceMap": true,
+      "debug": true,
+      "use": ["abort=decode_log/index/abort"]
+    },
+    "decode_log": {
+      "outFile": "build/decode_log/decode_log.wasm",
+      "textFile": "build/decode_log/decode_log.wat",
+      "sourceMap": true,
+      "optimizeLevel": 3,
+      "shrinkLevel": 0,
+      "converge": false,
+      "noAssert": false,
+      "use": ["abort=decode_log/index/abort"]
+    }
+  }
+}

--- a/as/bun.lock
+++ b/as/bun.lock
@@ -1,0 +1,31 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@shinzo/lenses",
+      "dependencies": {
+        "assemblyscript-json": "^1.1.0",
+      },
+      "devDependencies": {
+        "assemblyscript": "^0.25.0",
+        "bun-types": "^1.3.11",
+      },
+    },
+  },
+  "packages": {
+    "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+
+    "assemblyscript": ["assemblyscript@0.25.2", "", { "dependencies": { "binaryen": "110.0.0-nightly.20221105", "long": "^5.2.0" }, "bin": { "asc": "bin/asc.js", "asinit": "bin/asinit.js" } }, "sha512-67TQOMvKo23htvSK6lhOzsoQjnplNKkdwgq925uBvQZLDbg9pHfAWhg/R8i8tqKrtk6GH8haOJbQY4oNSQqehA=="],
+
+    "assemblyscript-json": ["assemblyscript-json@1.1.0", "", {}, "sha512-UbE8ts8csTWQgd5TnSPN7MRV9NveuHv1bVnKmDLoo/tzjqxkmsZb3lu59Uk8H7SGoqdkDSEE049alx/nHnSdFw=="],
+
+    "binaryen": ["binaryen@110.0.0-nightly.20221105", "", { "bin": { "wasm2js": "bin/wasm2js", "wasm-opt": "bin/wasm-opt" } }, "sha512-OBESOc51q3SwgG8Uv8nMzGnSq7LJpSB/Fu8B3AjlZg6YtCEwRnlDWlnwNB6mdql+VdexfKmNcsrs4K7MYidmdQ=="],
+
+    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+  }
+}

--- a/as/decode_log/decode_log.test.ts
+++ b/as/decode_log/decode_log.test.ts
@@ -1,0 +1,112 @@
+import { describe, test, expect } from "bun:test";
+import {
+  JSON_TYPE_ID, EOS_TYPE_ID,
+  encodeTransport, decodeTransport, writeToMemory,
+  loadWasm, setNextQueue,
+} from "../lib/test-helpers";
+import { ERC20_ABI, SAMPLE_LOG } from "../lib/test-data";
+
+describe("decode_log wasm", () => {
+  test("exports alloc, set_param, transform and imports lens.next", async () => {
+    const exports = await loadWasm(import.meta.dir);
+    expect(typeof exports.alloc).toBe("function");
+    expect(typeof exports.set_param).toBe("function");
+    expect(typeof exports.transform).toBe("function");
+    expect(exports.memory).toBeInstanceOf(WebAssembly.Memory);
+  });
+
+  test("set_param accepts ABI and returns nil", async () => {
+    const exports = await loadWasm(import.meta.dir);
+    const paramJson = JSON.stringify({ abi: ERC20_ABI });
+    const vec = encodeTransport(JSON_TYPE_ID, paramJson);
+    const ptr = writeToMemory(exports, vec);
+
+    const resultPtr = exports.set_param(ptr);
+    const view = new DataView(exports.memory.buffer);
+    const typeId = view.getInt8(resultPtr);
+    expect(typeId).toBe(0); // NIL_TYPE_ID = success
+  });
+
+  test("transform decodes an ERC-20 Transfer event", async () => {
+    const exports = await loadWasm(import.meta.dir);
+
+    // Set ABI parameter
+    const paramJson = JSON.stringify({ abi: ERC20_ABI });
+    const paramVec = encodeTransport(JSON_TYPE_ID, paramJson);
+    const paramPtr = writeToMemory(exports, paramVec);
+    exports.set_param(paramPtr);
+
+    // Queue the log document for next()
+    setNextQueue([encodeTransport(JSON_TYPE_ID, SAMPLE_LOG)]);
+
+    const resultPtr = exports.transform();
+    const result = decodeTransport(exports.memory, resultPtr);
+
+    expect(result.typeId).toBe(JSON_TYPE_ID);
+
+    const output = JSON.parse(result.payload);
+    expect(output.hash).toBe("0xabc123");
+    expect(output.from).toBe("0xsender");
+    expect(output.to).toBe("0xreceiver");
+    expect(output.blockNumber).toBe(18500000);
+    expect(output.logAddress).toBe("0xdac17f958d2ee523a2206206994597c13d831ec7");
+    expect(output.event).toBe("Transfer");
+    expect(output.signature).toBe("Transfer(address,address,uint256)");
+
+    // Check arguments
+    expect(output.arguments).toHaveLength(3);
+
+    expect(output.arguments[0].name).toBe("from");
+    expect(output.arguments[0].type).toBe("address");
+    expect(output.arguments[0].value).toBe("0xab5801a7d398351b8be11c439e05c5b3259aec9b");
+
+    expect(output.arguments[1].name).toBe("to");
+    expect(output.arguments[1].type).toBe("address");
+    expect(output.arguments[1].value).toBe("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
+
+    expect(output.arguments[2].name).toBe("value");
+    expect(output.arguments[2].type).toBe("uint256");
+    expect(output.arguments[2].value).toBe("2000000000"); // 0x77359400 = 2000000000
+  });
+
+  test("transform returns EOS when input stream is empty", async () => {
+    const exports = await loadWasm(import.meta.dir);
+
+    // Set ABI
+    const paramVec = encodeTransport(JSON_TYPE_ID, JSON.stringify({ abi: ERC20_ABI }));
+    exports.set_param(writeToMemory(exports, paramVec));
+
+    // Queue EOS
+    setNextQueue([encodeTransport(EOS_TYPE_ID, "")]);
+
+    const resultPtr = exports.transform();
+    const result = decodeTransport(exports.memory, resultPtr);
+    expect(result.typeId).toBe(EOS_TYPE_ID);
+  });
+
+  test("transform returns Unknown event when topic0 does not match ABI", async () => {
+    const exports = await loadWasm(import.meta.dir);
+
+    // Set ABI
+    const paramVec = encodeTransport(JSON_TYPE_ID, JSON.stringify({ abi: ERC20_ABI }));
+    exports.set_param(writeToMemory(exports, paramVec));
+
+    const unknownLog = JSON.stringify({
+      address: "0x1234",
+      topics: ["0x0000000000000000000000000000000000000000000000000000000000000000"],
+      data: "0x",
+      blockNumber: 100,
+      transaction: { hash: "0xdef", from: "0xa", to: "0xb" },
+    });
+    setNextQueue([encodeTransport(JSON_TYPE_ID, unknownLog)]);
+
+    const resultPtr = exports.transform();
+    const result = decodeTransport(exports.memory, resultPtr);
+
+    expect(result.typeId).toBe(JSON_TYPE_ID);
+    const output = JSON.parse(result.payload);
+    expect(output.event).toBe("Unknown");
+    expect(output.signature).toBe("");
+    expect(output.arguments).toHaveLength(0);
+  });
+});

--- a/as/decode_log/decoder.md
+++ b/as/decode_log/decoder.md
@@ -1,0 +1,35 @@
+# Decoder Lens
+
+Example usage with `viewkit` CLI:
+
+```bash
+# create a view with name "decoder"
+./build/viewkit view init decoder
+
+# basic query to pull in raw log data from Ethereum mainnet, with some nested transaction fields
+./build/viewkit view add query "Ethereum__Mainnet__Log { address topics data blockNumber transaction { hash from to } }" --name decoder
+
+# an SDL that returns transformed log data with event names from decoded ABI
+./build/viewkit view add sdl "type DecodedLog @materialized(if: false) {                                                               
+hash: String
+blockNumber: Int
+from: String
+to: String
+logAddress: String
+event: String
+signature: String
+}" --name decoder
+
+# attaching a recently-built lens with ERC-20 ABI
+./build/viewkit view add lens \
+--name decoder \
+--label decoder \
+--path ./as/build/decode_log/decode_log.wasm \
+--args '{"abi": "[{\"type\":\"event\",\"name\":\"Transfer\",\"inputs\":[{\"name\":\"from\",\"type\":\"address\",\"indexed\":true},{\"name\":\"to\",\"type\":\"address\",\"indexed\":true},{\"name\":\"value\",\"type\":\"uint256\",\"indexed\":false}]},{\"type\":\"event\",\"name\":\"Approval\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"indexed\":true},{\"name\":\"spender\",\"type\":\"address\",\"indexed\":true},{\"name\":\"value\",\"type\":\"uint256\",\"indexed\":false}]}]"}'
+
+# deploy to a local DefraDB with mock data
+./build/viewkit view deploy decoder --target local
+
+# deploy to ShinzoHub, so that a host can pick it up and run it against devnet data
+./build/viewkit view deploy decoder --target devnet --rpc http://rpc.devnet.shinzo.network:8545
+```

--- a/as/decode_log/decoder.ts
+++ b/as/decode_log/decoder.ts
@@ -1,0 +1,141 @@
+import { JSON } from "assemblyscript-json/assembly";
+import { AbiEvent, AbiInput } from "./types/abi";
+import { DecodedArgument } from "./types/output";
+import { keccak256 } from "../lib/keccak256";
+import { hexEncode, hexToDecimalString } from "../lib/hex";
+
+/** Parse a JSON ABI string into typed AbiEvent objects. Only "event" types are extracted. */
+export function parseAbi(abiJson: string): AbiEvent[] {
+  const events: AbiEvent[] = [];
+  const items = <JSON.Arr>JSON.parse(abiJson);
+  const arr = items.valueOf();
+
+  for (let i = 0; i < arr.length; i++) {
+    const item = <JSON.Obj>arr[i];
+
+    const typeField = item.getString("type");
+    if (typeField == null || typeField.valueOf() != "event") continue;
+
+    const nameField = item.getString("name");
+    if (nameField == null) continue;
+    const name = nameField.valueOf();
+
+    const inputsArr = item.getArr("inputs");
+    if (inputsArr == null) continue;
+
+    const inputs: AbiInput[] = [];
+    const inputValues = inputsArr.valueOf();
+    const types: string[] = [];
+
+    for (let j = 0; j < inputValues.length; j++) {
+      const inp = <JSON.Obj>inputValues[j];
+
+      const inpName = inp.getString("name");
+      const inpType = inp.getString("type");
+      if (inpName == null || inpType == null) continue;
+
+      const inpIndexed = inp.getBool("indexed");
+      const indexed = inpIndexed != null ? inpIndexed.valueOf() : false;
+
+      inputs.push(new AbiInput(inpName.valueOf(), inpType.valueOf(), indexed));
+      types.push(inpType.valueOf());
+    }
+
+    const sig = name + "(" + types.join(",") + ")";
+    const selector = computeSelector(sig);
+    events.push(new AbiEvent(name, sig, selector, inputs));
+  }
+
+  return events;
+}
+
+/** Compute the Keccak-256 selector hash for an event signature string. */
+export function computeSelector(signature: string): string {
+  const sigBytes = String.UTF8.encode(signature, false);
+  const hash = keccak256(Uint8Array.wrap(sigBytes));
+  return "0x" + hexEncode(hash);
+}
+
+/** Find the ABI event whose selector matches the given topic0 hash. */
+export function findMatchingEvent(events: AbiEvent[], topic0: string): AbiEvent | null {
+  const topic0Lower = topic0.toLowerCase();
+  for (let i = 0; i < events.length; i++) {
+    if (events[i].selector.toLowerCase() == topic0Lower) {
+      return events[i];
+    }
+  }
+  return null;
+}
+
+/** Decode an event's indexed and non-indexed parameters into typed DecodedArgument objects. */
+export function decodeEvent(event: AbiEvent, topics: string[], data: string): DecodedArgument[] {
+  const args: DecodedArgument[] = [];
+  const nonIndexed: AbiInput[] = [];
+  let topicIdx = 1;
+
+  for (let i = 0; i < event.inputs.length; i++) {
+    const inp = event.inputs[i];
+    if (inp.indexed) {
+      if (topicIdx < topics.length) {
+        const value = decodeParam(inp.typeName, topics[topicIdx]);
+        args.push(new DecodedArgument(inp.name, inp.typeName, value));
+      }
+      topicIdx++;
+    } else {
+      nonIndexed.push(inp);
+    }
+  }
+
+  // Decode non-indexed parameters from data field
+  if (data.length > 2) {
+    let dataHex = data;
+    if (dataHex.length >= 2 && dataHex.charAt(0) == "0" && (dataHex.charAt(1) == "x" || dataHex.charAt(1) == "X")) {
+      dataHex = dataHex.substring(2);
+    }
+
+    let offset = 0;
+    for (let i = 0; i < nonIndexed.length; i++) {
+      if (offset + 64 > dataHex.length) break;
+      const chunk = "0x" + dataHex.substring(offset, offset + 64);
+      const value = decodeParam(nonIndexed[i].typeName, chunk);
+      args.push(new DecodedArgument(nonIndexed[i].name, nonIndexed[i].typeName, value));
+      offset += 64;
+    }
+  }
+
+  return args;
+}
+
+/** Decode a single ABI-encoded parameter from its hex representation. */
+export function decodeParam(typeName: string, hexData: string): string {
+  let clean = hexData;
+  if (clean.length >= 2 && clean.charAt(0) == "0" && (clean.charAt(1) == "x" || clean.charAt(1) == "X")) {
+    clean = clean.substring(2);
+  }
+
+  if (
+    typeName == "uint256" || typeName == "uint128" || typeName == "uint64" ||
+    typeName == "uint32" || typeName == "uint16" || typeName == "uint8" ||
+    typeName == "int256" || typeName == "int128" || typeName == "int64" ||
+    typeName == "int32" || typeName == "int16" || typeName == "int8"
+  ) {
+    return hexToDecimalString(clean);
+  }
+
+  if (typeName == "address") {
+    if (clean.length >= 40) {
+      return "0x" + clean.substring(clean.length - 40);
+    }
+    return "0x" + clean;
+  }
+
+  if (typeName == "bool") {
+    return clean.endsWith("1") ? "true" : "false";
+  }
+
+  if (typeName == "bytes32" || typeName == "bytes20" || typeName == "bytes16" || typeName == "bytes4") {
+    return "0x" + clean;
+  }
+
+  return "unsupported type: " + typeName;
+}

--- a/as/decode_log/index.ts
+++ b/as/decode_log/index.ts
@@ -1,0 +1,95 @@
+import { JSON } from "assemblyscript-json/assembly";
+import {
+  TransportMessage,
+  fromTransportVec,
+  toTransportVec,
+  nilPtr,
+  JSON_TYPE_ID,
+  EOS_TYPE_ID,
+  ERROR_TYPE_ID,
+} from "../lib/transport";
+import { Parameters } from "./types/params";
+import { InputLog } from "./types/input";
+import { OutputLog } from "./types/output";
+import { parseAbi, findMatchingEvent, decodeEvent } from "./decoder";
+
+// @ts-ignore: decorator
+@external("lens", "next")
+declare function next(): usize;
+
+// @ts-ignore: decorator
+function abort(
+  message: string | null,
+  fileName: string | null,
+  lineNumber: u32,
+  columnNumber: u32
+): void {
+  unreachable();
+}
+
+let params: Parameters | null = null;
+
+export function alloc(size: usize): usize {
+  return heap.alloc(size);
+}
+
+export function set_param(ptr: usize): usize {
+  const msg = fromTransportVec(ptr);
+  if (msg.isEndOfStream) {
+    return toTransportVec(ERROR_TYPE_ID, "unexpected end of stream in set_param");
+  }
+
+  const parsed = <JSON.Obj>JSON.parse(msg.payload);
+  params = Parameters.fromJson(parsed);
+
+  if (params!.abi.length == 0) {
+    return toTransportVec(ERROR_TYPE_ID, "missing 'abi' parameter");
+  }
+
+  heap.free(ptr);
+  return nilPtr();
+}
+
+export function transform(): usize {
+  const ptr = next();
+  const msg = fromTransportVec(ptr);
+
+  if (msg.isEndOfStream) {
+    heap.free(ptr);
+    return toTransportVec(EOS_TYPE_ID, "");
+  }
+
+  if (msg.payload.length == 0) {
+    heap.free(ptr);
+    return toTransportVec(JSON_TYPE_ID, "{}");
+  }
+
+  const doc = <JSON.Obj>JSON.parse(msg.payload);
+  const input = InputLog.fromJson(doc);
+  const output = processLog(input);
+  const json = output.toJson();
+
+  heap.free(ptr);
+  return toTransportVec(JSON_TYPE_ID, json);
+}
+
+function processLog(input: InputLog): OutputLog {
+  const out = new OutputLog();
+  out.hash = input.transaction.hash;
+  out.from = input.transaction.from;
+  out.to = input.transaction.to;
+  out.blockNumber = input.blockNumber;
+  out.logAddress = input.address;
+
+  if (input.topics.length > 0 && params != null && params!.abi.length > 0) {
+    const events = parseAbi(params!.abi);
+    const matched = findMatchingEvent(events, input.topics[0]);
+    if (matched != null) {
+      out.event = matched.name;
+      out.signature = matched.signature;
+      out.arguments = decodeEvent(matched, input.topics, input.data);
+    }
+  }
+
+  return out;
+}

--- a/as/decode_log/types/abi.ts
+++ b/as/decode_log/types/abi.ts
@@ -1,0 +1,27 @@
+/** A single input parameter from an ABI event definition. */
+export class AbiInput {
+  name: string;
+  typeName: string;
+  indexed: bool;
+
+  constructor(name: string, typeName: string, indexed: bool) {
+    this.name = name;
+    this.typeName = typeName;
+    this.indexed = indexed;
+  }
+}
+
+/** A parsed ABI event with its precomputed selector hash. */
+export class AbiEvent {
+  name: string;
+  signature: string;
+  selector: string;
+  inputs: AbiInput[];
+
+  constructor(name: string, signature: string, selector: string, inputs: AbiInput[]) {
+    this.name = name;
+    this.signature = signature;
+    this.selector = selector;
+    this.inputs = inputs;
+  }
+}

--- a/as/decode_log/types/input.ts
+++ b/as/decode_log/types/input.ts
@@ -1,0 +1,58 @@
+import { JSON } from "assemblyscript-json/assembly";
+
+/** Nested transaction context from the input log document. */
+export class Transaction {
+  hash: string = "";
+  from: string = "";
+  to: string = "";
+}
+
+/** Raw Ethereum log document as received from the LensVM pipeline. */
+export class InputLog {
+  address: string = "";
+  topics: string[] = [];
+  data: string = "";
+  blockNumber: i64 = 0;
+  transaction: Transaction = new Transaction();
+
+  /** Parse an InputLog from a JSON.Obj, encapsulating all nullable-check extraction. */
+  static fromJson(doc: JSON.Obj): InputLog {
+    const log = new InputLog();
+
+    // address
+    const addrVal = doc.getString("address");
+    if (addrVal != null) log.address = addrVal.valueOf();
+
+    // blockNumber
+    const blockNumVal = doc.getInteger("blockNumber");
+    if (blockNumVal != null) log.blockNumber = blockNumVal.valueOf();
+
+    // data
+    const dataVal = doc.getString("data");
+    if (dataVal != null) log.data = dataVal.valueOf();
+
+    // topics
+    const topicsArr = doc.getArr("topics");
+    if (topicsArr != null) {
+      const values = topicsArr.valueOf();
+      for (let i = 0; i < values.length; i++) {
+        if (values[i].isString) {
+          log.topics.push((<JSON.Str>values[i]).valueOf());
+        }
+      }
+    }
+
+    // transaction (nested object)
+    const txObj = doc.getObj("transaction");
+    if (txObj != null) {
+      const h = txObj.getString("hash");
+      if (h != null) log.transaction.hash = h.valueOf();
+      const f = txObj.getString("from");
+      if (f != null) log.transaction.from = f.valueOf();
+      const t = txObj.getString("to");
+      if (t != null) log.transaction.to = t.valueOf();
+    }
+
+    return log;
+  }
+}

--- a/as/decode_log/types/output.ts
+++ b/as/decode_log/types/output.ts
@@ -1,0 +1,54 @@
+import { JSONEncoder } from "assemblyscript-json/assembly";
+
+/** A single decoded event argument. */
+export class DecodedArgument {
+  name: string;
+  type: string;
+  value: string;
+
+  constructor(name: string, type: string, value: string) {
+    this.name = name;
+    this.type = type;
+    this.value = value;
+  }
+}
+
+/** Decoded event log output document. */
+export class OutputLog {
+  hash: string = "";
+  from: string = "";
+  to: string = "";
+  blockNumber: i64 = 0;
+  logAddress: string = "";
+  event: string = "Unknown";
+  signature: string = "";
+  arguments: DecodedArgument[] = [];
+
+  /** Serialize this output to a JSON string using JSONEncoder. */
+  toJson(): string {
+    const enc = new JSONEncoder();
+    enc.pushObject(null);
+
+    enc.setString("hash", this.hash);
+    enc.setInteger("blockNumber", this.blockNumber);
+    enc.setString("from", this.from);
+    enc.setString("to", this.to);
+    enc.setString("logAddress", this.logAddress);
+    enc.setString("event", this.event);
+    enc.setString("signature", this.signature);
+
+    enc.pushArray("arguments");
+    for (let i = 0; i < this.arguments.length; i++) {
+      const arg = this.arguments[i];
+      enc.pushObject(null);
+      enc.setString("name", arg.name);
+      enc.setString("type", arg.type);
+      enc.setString("value", arg.value);
+      enc.popObject();
+    }
+    enc.popArray();
+
+    enc.popObject();
+    return enc.toString();
+  }
+}

--- a/as/decode_log/types/params.ts
+++ b/as/decode_log/types/params.ts
@@ -1,0 +1,32 @@
+import { JSON } from "assemblyscript-json/assembly";
+
+/** Lens parameters containing the ABI definition string. */
+export class Parameters {
+  abi: string = "";
+
+  /**
+   * Parse Parameters from a JSON.Obj.
+   * Accepts "abi" as either a JSON string or a JSON array:
+   *   {"abi": "[{...}]"}       ← string (from Go map[string]any with string value)
+   *   {"abi": [{...}]}         ← array  (from CLI --args with inline JSON array)
+   */
+  static fromJson(obj: JSON.Obj): Parameters {
+    const p = new Parameters();
+
+    // Try string first (e.g. from Go service layer or escaped CLI input)
+    const abiStr = obj.getString("abi");
+    if (abiStr != null) {
+      p.abi = abiStr.valueOf();
+      return p;
+    }
+
+    // Fall back to array — stringify it so the rest of the pipeline works
+    const abiArr = obj.getArr("abi");
+    if (abiArr != null) {
+      p.abi = abiArr.stringify();
+      return p;
+    }
+
+    return p;
+  }
+}

--- a/as/lib/hex.ts
+++ b/as/lib/hex.ts
@@ -1,0 +1,126 @@
+// Hex encoding/decoding utilities for Ethereum data
+
+const HEX_CHARS: string = "0123456789abcdef";
+
+/** Convert a hex character code to its nibble value (0-15). Returns 0 for invalid chars. */
+function hexCharToNibble(c: i32): u8 {
+  if (c >= 48 && c <= 57) return <u8>(c - 48);        // '0'-'9'
+  if (c >= 97 && c <= 102) return <u8>(c - 97 + 10);  // 'a'-'f'
+  if (c >= 65 && c <= 70) return <u8>(c - 65 + 10);   // 'A'-'F'
+  return 0;
+}
+
+/** Decode a hex string to bytes. Strips leading "0x" if present. */
+export function hexDecode(hex: string): Uint8Array {
+  let start = 0;
+  if (hex.length >= 2 && hex.charAt(0) == "0" && (hex.charAt(1) == "x" || hex.charAt(1) == "X")) {
+    start = 2;
+  }
+
+  const cleanLen = hex.length - start;
+  // Handle odd-length hex strings by padding with a leading zero
+  const byteLen = (cleanLen + 1) >> 1;
+  const result = new Uint8Array(byteLen);
+
+  let offset = 0;
+  let i = start;
+  if (cleanLen & 1) {
+    // Odd length: first byte is just a single nibble
+    result[0] = hexCharToNibble(hex.charCodeAt(i));
+    i++;
+    offset = 1;
+  }
+
+  while (i < hex.length) {
+    const hi = hexCharToNibble(hex.charCodeAt(i));
+    const lo = hexCharToNibble(hex.charCodeAt(i + 1));
+    result[offset] = (hi << 4) | lo;
+    i += 2;
+    offset++;
+  }
+
+  return result;
+}
+
+/** Encode bytes to a lowercase hex string (no "0x" prefix). */
+export function hexEncode(bytes: Uint8Array): string {
+  let result = "";
+  for (let i = 0; i < bytes.length; i++) {
+    const b = bytes[i];
+    result += HEX_CHARS.charAt((b >> 4) & 0x0f);
+    result += HEX_CHARS.charAt(b & 0x0f);
+  }
+  return result;
+}
+
+/**
+ * Parse a uint256 from a hex string (up to 128 bits supported via two u64s).
+ * Returns the decimal string representation.
+ * For values > u64 max, we parse into high and low 64-bit parts.
+ */
+export function hexToDecimalString(hex: string): string {
+  let clean = hex;
+  if (clean.length >= 2 && clean.charAt(0) == "0" && (clean.charAt(1) == "x" || clean.charAt(1) == "X")) {
+    clean = clean.substring(2);
+  }
+
+  // Strip leading zeros
+  let startIdx = 0;
+  while (startIdx < clean.length - 1 && clean.charAt(startIdx) == "0") {
+    startIdx++;
+  }
+  clean = clean.substring(startIdx);
+
+  // If it fits in a u64 (16 hex chars = 64 bits), parse directly
+  if (clean.length <= 16) {
+    let value: u64 = 0;
+    for (let i = 0; i < clean.length; i++) {
+      value = (value << 4) | <u64>hexCharToNibble(clean.charCodeAt(i));
+    }
+    return value.toString();
+  }
+
+  // For larger values, use digit-by-digit decimal arithmetic
+  return hexToDecimalBignum(clean);
+}
+
+/** Convert arbitrarily large hex to decimal string using digit-by-digit multiplication. */
+function hexToDecimalBignum(hex: string): string {
+  // Represent the decimal result as an array of digits (least significant first)
+  let digits: u8[] = [0];
+
+  for (let i = 0; i < hex.length; i++) {
+    const nibble = hexCharToNibble(hex.charCodeAt(i));
+
+    // Multiply current result by 16
+    let carry: u32 = 0;
+    for (let j = 0; j < digits.length; j++) {
+      const prod = <u32>digits[j] * 16 + carry;
+      digits[j] = <u8>(prod % 10);
+      carry = prod / 10;
+    }
+    while (carry > 0) {
+      digits.push(<u8>(carry % 10));
+      carry = carry / 10;
+    }
+
+    // Add the nibble
+    carry = <u32>nibble;
+    for (let j = 0; j < digits.length && carry > 0; j++) {
+      const sum = <u32>digits[j] + carry;
+      digits[j] = <u8>(sum % 10);
+      carry = sum / 10;
+    }
+    while (carry > 0) {
+      digits.push(<u8>(carry % 10));
+      carry = carry / 10;
+    }
+  }
+
+  // Convert digits array to string (reverse order — most significant first)
+  let result = "";
+  for (let i = digits.length - 1; i >= 0; i--) {
+    result += String.fromCharCode(48 + <i32>digits[i]);
+  }
+  return result;
+}

--- a/as/lib/keccak256.ts
+++ b/as/lib/keccak256.ts
@@ -1,0 +1,150 @@
+// Pure AssemblyScript Keccak-256 implementation (Ethereum variant)
+// Keccak-256 uses padding byte 0x01, NOT SHA3-256 which uses 0x06.
+
+// Keccak-f[1600] round constants
+const RC: u64[] = [
+  0x0000000000000001, 0x0000000000008082, 0x800000000000808a, 0x8000000080008000,
+  0x000000000000808b, 0x0000000080000001, 0x8000000080008081, 0x8000000000008009,
+  0x000000000000008a, 0x0000000000000088, 0x0000000080008009, 0x000000008000000a,
+  0x000000008000808b, 0x800000000000008b, 0x8000000000008089, 0x8000000000008003,
+  0x8000000000008002, 0x8000000000000080, 0x000000000000800a, 0x800000008000000a,
+  0x8000000080008081, 0x8000000000008080, 0x0000000080000001, 0x8000000080008008,
+];
+
+// Rotation offsets for rho step
+const ROTATIONS: i32[] = [
+   0,  1, 62, 28, 27,
+  36, 44,  6, 55, 20,
+   3, 10, 43, 25, 39,
+  41, 45, 15, 21,  8,
+  18,  2, 61, 56, 14,
+];
+
+// Pi step permutation indices
+const PI: i32[] = [
+   0, 10, 20,  5, 15,
+  16,  1, 11, 21,  6,
+   7, 17,  2, 12, 22,
+  23,  8, 18,  3, 13,
+  14, 24,  9, 19,  4,
+];
+
+const RATE: i32 = 136; // bytes (1088 bits) for Keccak-256
+
+/** Keccak-f[1600] permutation: 24 rounds of theta/rho/pi/chi/iota */
+function keccakF(state: StaticArray<u64>): void {
+  for (let round = 0; round < 24; round++) {
+    // Theta
+    const c0 = state[0] ^ state[5] ^ state[10] ^ state[15] ^ state[20];
+    const c1 = state[1] ^ state[6] ^ state[11] ^ state[16] ^ state[21];
+    const c2 = state[2] ^ state[7] ^ state[12] ^ state[17] ^ state[22];
+    const c3 = state[3] ^ state[8] ^ state[13] ^ state[18] ^ state[23];
+    const c4 = state[4] ^ state[9] ^ state[14] ^ state[19] ^ state[24];
+
+    const d0 = c4 ^ rotl<u64>(c1, 1);
+    const d1 = c0 ^ rotl<u64>(c2, 1);
+    const d2 = c1 ^ rotl<u64>(c3, 1);
+    const d3 = c2 ^ rotl<u64>(c4, 1);
+    const d4 = c3 ^ rotl<u64>(c0, 1);
+
+    state[ 0] ^= d0; state[ 5] ^= d0; state[10] ^= d0; state[15] ^= d0; state[20] ^= d0;
+    state[ 1] ^= d1; state[ 6] ^= d1; state[11] ^= d1; state[16] ^= d1; state[21] ^= d1;
+    state[ 2] ^= d2; state[ 7] ^= d2; state[12] ^= d2; state[17] ^= d2; state[22] ^= d2;
+    state[ 3] ^= d3; state[ 8] ^= d3; state[13] ^= d3; state[18] ^= d3; state[23] ^= d3;
+    state[ 4] ^= d4; state[ 9] ^= d4; state[14] ^= d4; state[19] ^= d4; state[24] ^= d4;
+
+    // Rho + Pi (combined)
+    const temp = new StaticArray<u64>(25);
+    for (let i = 0; i < 25; i++) {
+      unchecked(temp[PI[i]] = rotl<u64>(state[i], ROTATIONS[i]));
+    }
+
+    // Chi
+    for (let y = 0; y < 5; y++) {
+      const base = y * 5;
+      const t0 = unchecked(temp[base + 0]);
+      const t1 = unchecked(temp[base + 1]);
+      const t2 = unchecked(temp[base + 2]);
+      const t3 = unchecked(temp[base + 3]);
+      const t4 = unchecked(temp[base + 4]);
+      unchecked(state[base + 0] = t0 ^ (~t1 & t2));
+      unchecked(state[base + 1] = t1 ^ (~t2 & t3));
+      unchecked(state[base + 2] = t2 ^ (~t3 & t4));
+      unchecked(state[base + 3] = t3 ^ (~t4 & t0));
+      unchecked(state[base + 4] = t4 ^ (~t0 & t1));
+    }
+
+    // Iota
+    unchecked(state[0] ^= RC[round]);
+  }
+}
+
+/**
+ * Compute Keccak-256 hash of input data.
+ * Returns 32 bytes.
+ */
+export function keccak256(data: Uint8Array): Uint8Array {
+  const state = new StaticArray<u64>(25);
+
+  // Absorb phase
+  let offset = 0;
+  while (offset + RATE <= data.length) {
+    // XOR a full rate block into the state
+    for (let i = 0; i < RATE; i += 8) {
+      const laneIdx = i >> 3;
+      const b0 = <u64>data[offset + i];
+      const b1 = <u64>data[offset + i + 1] << 8;
+      const b2 = <u64>data[offset + i + 2] << 16;
+      const b3 = <u64>data[offset + i + 3] << 24;
+      const b4 = <u64>data[offset + i + 4] << 32;
+      const b5 = <u64>data[offset + i + 5] << 40;
+      const b6 = <u64>data[offset + i + 6] << 48;
+      const b7 = <u64>data[offset + i + 7] << 56;
+      unchecked(state[laneIdx] ^= b0 | b1 | b2 | b3 | b4 | b5 | b6 | b7);
+    }
+    keccakF(state);
+    offset += RATE;
+  }
+
+  // Pad: remaining bytes + Keccak padding
+  const remaining = data.length - offset;
+  const padBlock = new Uint8Array(RATE);
+  for (let i = 0; i < remaining; i++) {
+    padBlock[i] = data[offset + i];
+  }
+  // Keccak padding: 0x01 after data, 0x80 at end of block
+  padBlock[remaining] = 0x01;
+  padBlock[RATE - 1] |= 0x80;
+
+  // XOR pad block into state
+  for (let i = 0; i < RATE; i += 8) {
+    const laneIdx = i >> 3;
+    const b0 = <u64>padBlock[i];
+    const b1 = <u64>padBlock[i + 1] << 8;
+    const b2 = <u64>padBlock[i + 2] << 16;
+    const b3 = <u64>padBlock[i + 3] << 24;
+    const b4 = <u64>padBlock[i + 4] << 32;
+    const b5 = <u64>padBlock[i + 5] << 40;
+    const b6 = <u64>padBlock[i + 6] << 48;
+    const b7 = <u64>padBlock[i + 7] << 56;
+    unchecked(state[laneIdx] ^= b0 | b1 | b2 | b3 | b4 | b5 | b6 | b7);
+  }
+  keccakF(state);
+
+  // Squeeze: extract first 32 bytes (4 lanes)
+  const hash = new Uint8Array(32);
+  for (let lane = 0; lane < 4; lane++) {
+    const val = unchecked(state[lane]);
+    const base = lane * 8;
+    hash[base + 0] = <u8>(val & 0xff);
+    hash[base + 1] = <u8>((val >> 8) & 0xff);
+    hash[base + 2] = <u8>((val >> 16) & 0xff);
+    hash[base + 3] = <u8>((val >> 24) & 0xff);
+    hash[base + 4] = <u8>((val >> 32) & 0xff);
+    hash[base + 5] = <u8>((val >> 40) & 0xff);
+    hash[base + 6] = <u8>((val >> 48) & 0xff);
+    hash[base + 7] = <u8>((val >> 56) & 0xff);
+  }
+
+  return hash;
+}

--- a/as/lib/test-data.ts
+++ b/as/lib/test-data.ts
@@ -1,0 +1,39 @@
+export const ERC20_ABI = JSON.stringify([
+  {
+    type: "event",
+    name: "Transfer",
+    inputs: [
+      { name: "from", type: "address", indexed: true },
+      { name: "to", type: "address", indexed: true },
+      { name: "value", type: "uint256", indexed: false },
+    ],
+  },
+  {
+    type: "event",
+    name: "Approval",
+    inputs: [
+      { name: "owner", type: "address", indexed: true },
+      { name: "spender", type: "address", indexed: true },
+      { name: "value", type: "uint256", indexed: false },
+    ],
+  },
+]);
+
+// keccak256("Transfer(address,address,uint256)")
+const TRANSFER_TOPIC0 = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+
+export const SAMPLE_LOG = JSON.stringify({
+  address: "0xdac17f958d2ee523a2206206994597c13d831ec7",
+  topics: [
+    TRANSFER_TOPIC0,
+    "0x000000000000000000000000ab5801a7d398351b8be11c439e05c5b3259aec9b",
+    "0x000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+  ],
+  data: "0x0000000000000000000000000000000000000000000000000000000077359400",
+  blockNumber: 18500000,
+  transaction: {
+    hash: "0xabc123",
+    from: "0xsender",
+    to: "0xreceiver",
+  },
+});

--- a/as/lib/test-helpers.ts
+++ b/as/lib/test-helpers.ts
@@ -1,0 +1,88 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+export const JSON_TYPE_ID = 1;
+export const EOS_TYPE_ID = 127;
+
+export type WasmExports = {
+  memory: WebAssembly.Memory;
+  alloc: (size: number) => number;
+  set_param: (ptr: number) => number;
+  transform: () => number;
+};
+
+/** Encode a JSON string into a LensVM transport vector. */
+export function encodeTransport(typeId: number, payload: string): Uint8Array {
+  const payloadBytes = new TextEncoder().encode(payload);
+  const buf = new Uint8Array(1 + 4 + payloadBytes.length);
+  const view = new DataView(buf.buffer);
+  view.setInt8(0, typeId);
+  view.setUint32(1, payloadBytes.length, true); // little-endian
+  buf.set(payloadBytes, 5);
+  return buf;
+}
+
+/** Decode a LensVM transport vector from wasm memory. */
+export function decodeTransport(memory: WebAssembly.Memory, ptr: number): { typeId: number; payload: string } {
+  const view = new DataView(memory.buffer);
+  const typeId = view.getInt8(ptr);
+  if (typeId === EOS_TYPE_ID) {
+    return { typeId, payload: "" };
+  }
+  const len = view.getUint32(ptr + 1, true);
+  const payloadBytes = new Uint8Array(memory.buffer, ptr + 5, len);
+  const payload = new TextDecoder().decode(payloadBytes);
+  return { typeId, payload };
+}
+
+/** Write a transport vector into wasm memory and return the pointer. */
+export function writeToMemory(
+  exports: { memory: WebAssembly.Memory; alloc: (size: number) => number },
+  data: Uint8Array
+): number {
+  const ptr = exports.alloc(data.length);
+  new Uint8Array(exports.memory.buffer).set(data, ptr);
+  return ptr;
+}
+
+/** Queue of transport vectors to be returned by the mocked next() function. */
+export let nextQueue: Uint8Array[] = [];
+
+export function setNextQueue(queue: Uint8Array[]) {
+  nextQueue = queue;
+}
+
+export async function loadWasm(wasmDir: string): Promise<WasmExports> {
+  const wasmPath = join(wasmDir, "..", "build", "decode_log", "decode_log.wasm");
+  const wasmBuffer = readFileSync(wasmPath);
+
+  let memoryRef: WebAssembly.Memory;
+  let allocFn: (size: number) => number;
+
+  const { instance } = await WebAssembly.instantiate(wasmBuffer, {
+    lens: {
+      next(): number {
+        if (nextQueue.length === 0) {
+          const eos = encodeTransport(EOS_TYPE_ID, "");
+          const ptr = allocFn(eos.length);
+          new Uint8Array(memoryRef.buffer).set(eos, ptr);
+          return ptr;
+        }
+        const vec = nextQueue.shift()!;
+        const ptr = allocFn(vec.length);
+        new Uint8Array(memoryRef.buffer).set(vec, ptr);
+        return ptr;
+      },
+    },
+    env: {
+      abort: () => { throw new Error("abort called"); },
+    },
+  });
+
+  const exports = instance.exports as WasmExports;
+
+  memoryRef = exports.memory;
+  allocFn = exports.alloc;
+
+  return exports;
+}

--- a/as/lib/transport.ts
+++ b/as/lib/transport.ts
@@ -1,0 +1,71 @@
+// LensVM binary transport protocol
+// Format: [TypeId: i8][Length: u32 LE][Payload: bytes]
+
+export const JSON_TYPE_ID: i8 = 1;
+export const EOS_TYPE_ID: i8 = 127;
+export const ERROR_TYPE_ID: i8 = -1;
+export const NIL_TYPE_ID: i8 = 0;
+
+export class TransportMessage {
+  typeId: i8;
+  payload: string;
+
+  constructor(typeId: i8, payload: string) {
+    this.typeId = typeId;
+    this.payload = payload;
+  }
+
+  get isEndOfStream(): bool {
+    return this.typeId == EOS_TYPE_ID;
+  }
+
+  get isJson(): bool {
+    return this.typeId == JSON_TYPE_ID;
+  }
+
+  get isError(): bool {
+    return this.typeId == ERROR_TYPE_ID;
+  }
+
+  get isNil(): bool {
+    return this.typeId == NIL_TYPE_ID;
+  }
+}
+
+/** Parse incoming LensVM transport vector from a raw memory pointer. */
+export function fromTransportVec(ptr: usize): TransportMessage {
+  const typeId = load<i8>(ptr);
+  if (typeId == EOS_TYPE_ID) {
+    return new TransportMessage(EOS_TYPE_ID, "");
+  }
+  const len = load<u32>(ptr + 1);
+  const payload = String.UTF8.decodeUnsafe(ptr + 1 + 4, len, false);
+  return new TransportMessage(typeId, payload);
+}
+
+/** Write an outgoing LensVM transport vector and return a pointer to it. */
+export function toTransportVec(typeId: i8, message: string): usize {
+  const len = String.UTF8.byteLength(message, false);
+  const total = 1 + 4 + len;
+  const ptr = heap.alloc(total);
+
+  store<i8>(ptr, typeId);
+
+  if (typeId == EOS_TYPE_ID) {
+    // End-of-stream has no payload beyond type byte
+  } else {
+    store<u32>(ptr + 1, len);
+    if (len > 0) {
+      String.UTF8.encodeUnsafe(changetype<usize>(message), message.length, ptr + 1 + 4, false);
+    }
+  }
+
+  return ptr;
+}
+
+/** Return a nil (type 0) pointer — used to signal success from set_param. */
+export function nilPtr(): usize {
+  const ptr = heap.alloc(1);
+  store<i8>(ptr, NIL_TYPE_ID);
+  return ptr;
+}

--- a/as/package.json
+++ b/as/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@shinzo/lenses",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "build": "bun run build:decode_log",
+    "build:decode_log": "asc decode_log/index.ts --target decode_log",
+    "build:decode_log:debug": "asc decode_log/index.ts --target decode_log_debug",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "assemblyscript-json": "^1.1.0"
+  },
+  "devDependencies": {
+    "assemblyscript": "^0.25.0",
+    "bun-types": "^1.3.11"
+  }
+}

--- a/as/tsconfig.json
+++ b/as/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "assemblyscript/std/assembly.json",
+  "include": ["./**/*.ts"],
+  "exclude": ["./**/*.test.ts", "./lib/test-helpers.ts", "./lib/test-data.ts"]
+}

--- a/as/tsconfig.test.json
+++ b/as/tsconfig.test.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "types": ["bun-types"],
+    "esModuleInterop": true,
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["./**/*.test.ts", "./lib/test-helpers.ts", "./lib/test-data.ts"]
+}


### PR DESCRIPTION
An example usage of AssemblyScript for creating a working WASM file that can actually decode logs for a given ABI.

This is basically a port of decode_log lens from the bucket repo: https://github.com/shinzonetwork/wasm-bucket/tree/main/bucket/decode_log.

I don't expect this PR to be merged, at least not in this repo. But visually I'd like to leave it here for a review.