### PR TITLE
fix: verify tx receipt after view deployment to detect on-chain reverts

### DIFF
--- a/core/service/deploy.go
+++ b/core/service/deploy.go
@@ -33,6 +33,12 @@ type ViewLite struct {
 	Transform models.Transform `json:"transform"`
 }
 
+type txResult struct {
+	TxHash      string
+	GasUsed     uint64
+	BlockNumber uint64
+}
+
 // ---------------------------
 // Deploy entry
 // ---------------------------
@@ -163,7 +169,7 @@ func StartLocalNodeTestAndDeploy(
 		return err
 	}
 
-	txHash, err := sendRegisterTx(rpc, SHINZO_HUB_PRECOMPILED_VIEW_REGISTRY_ADDRESS, privateKey, wireBytes)
+	result, err := sendRegisterTx(rpc, SHINZO_HUB_PRECOMPILED_VIEW_REGISTRY_ADDRESS, privateKey, wireBytes)
 	if err != nil {
 		return err
 	}
@@ -172,8 +178,10 @@ func StartLocalNodeTestAndDeploy(
 	fmt.Println("----------------------------------------")
 	fmt.Printf("🔑 View ID:           %s\n", viewID)
 	fmt.Printf("🔑 View Key:          %s\n", viewHash.Hex())
-	fmt.Printf("📦 Transaction Hash:  %s\n", txHash)
-	fmt.Printf("Wire bytes (tx data):%d\n", len(wireBytes))
+	fmt.Printf("📦 Transaction Hash:  %s\n", result.TxHash)
+	fmt.Printf("⛽ Gas Used:          %d\n", result.GasUsed)
+	fmt.Printf("🧱 Block Number:      %d\n", result.BlockNumber)
+	fmt.Printf("📏 Wire bytes (size): %d\n", len(wireBytes))
 	fmt.Println("----------------------------------------")
 
 	return nil
@@ -211,10 +219,10 @@ func sendRegisterTx(
 	contractAddr string,
 	privateKey *ecdsa.PrivateKey,
 	payload []byte,
-) (string, error) {
+) (txResult, error) {
 	client, err := ethclient.Dial(rpcURL)
 	if err != nil {
-		return "", fmt.Errorf("failed to connect to RPC: %w", err)
+		return txResult{}, fmt.Errorf("failed to connect to RPC: %w", err)
 	}
 	defer client.Close()
 
@@ -225,17 +233,17 @@ func sendRegisterTx(
 
 	nonce, err := client.PendingNonceAt(ctx, fromAddress)
 	if err != nil {
-		return "", fmt.Errorf("failed to get nonce: %w", err)
+		return txResult{}, fmt.Errorf("failed to get nonce: %w", err)
 	}
 
 	gasPrice, err := client.SuggestGasPrice(ctx)
 	if err != nil {
-		return "", fmt.Errorf("failed to get gas price: %w", err)
+		return txResult{}, fmt.Errorf("failed to get gas price: %w", err)
 	}
 
 	chainID, err := client.NetworkID(ctx)
 	if err != nil {
-		return "", fmt.Errorf("failed to get chain ID: %w", err)
+		return txResult{}, fmt.Errorf("failed to get chain ID: %w", err)
 	}
 
 	// Encode register(bytes) calldata
@@ -262,14 +270,43 @@ func sendRegisterTx(
 
 	signedTx, err := types.SignTx(tx, types.NewEIP155Signer(chainID), privateKey)
 	if err != nil {
-		return "", fmt.Errorf("failed to sign tx: %w", err)
+		return txResult{}, fmt.Errorf("failed to sign tx: %w", err)
 	}
 
 	if err := client.SendTransaction(ctx, signedTx); err != nil {
-		return "", fmt.Errorf("failed to send tx: %w", err)
+		return txResult{}, fmt.Errorf("failed to send tx: %w", err)
 	}
 
-	return signedTx.Hash().Hex(), nil
+	txHash := signedTx.Hash()
+	fmt.Printf("⏳ Transaction sent (%s). Waiting for confirmation...\n", txHash.Hex())
+
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return txResult{}, fmt.Errorf("timed out waiting for tx receipt (tx may still succeed): %s", txHash.Hex())
+		case <-ticker.C:
+			receipt, err := client.TransactionReceipt(ctx, txHash)
+			if err != nil {
+				continue
+			}
+
+			if receipt.Status == types.ReceiptStatusFailed {
+				return txResult{}, fmt.Errorf(
+					"❌ transaction reverted on-chain (gas used: %d, tx: %s)",
+					receipt.GasUsed, txHash.Hex(),
+				)
+			}
+
+			return txResult{
+				TxHash:      txHash.Hex(),
+				GasUsed:     receipt.GasUsed,
+				BlockNumber: receipt.BlockNumber.Uint64(),
+			}, nil
+		}
+	}
 }
 
 func EncodeRegisterBytesCalldata(payload []byte) []byte {

--- a/core/service/deploy_revert_test.go
+++ b/core/service/deploy_revert_test.go
@@ -1,0 +1,63 @@
+package service
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+// TestSendRegisterTx_RevertsOnInvalidPayload verifies that sendRegisterTx
+// returns an error when the on-chain transaction reverts.
+//
+// This is an integration test that requires a running local ShinzoHub node.
+// It sends garbage bytes (not valid VWL format) to the ViewRegistry
+// precompile, which causes viewbundle.DecodeHeader() to fail and the
+// precompile to revert. The test confirms that sendRegisterTx detects
+// the revert via receipt status instead of silently reporting success.
+//
+// Prerequisites:
+//   - Local ShinzoHub testnet: cd shinzohub && make sh-testnet
+//   - Export key: export TEST_PRIVATE_KEY=$(./build/shinzohubd keys unsafe-export-eth-key acc0 --keyring-backend test --home ~/.shinzohub)
+//
+// Run:
+//
+//	TEST_PRIVATE_KEY=<hex> go test ./core/service/ -run TestSendRegisterTx_RevertsOnInvalidPayload -v -count=1
+func TestSendRegisterTx_RevertsOnInvalidPayload(t *testing.T) {
+	rpcURL := "http://localhost:8545"
+
+	client, err := ethclient.Dial(rpcURL)
+	if err != nil {
+		t.Skip("skipping: local chain not reachable at", rpcURL)
+	}
+	client.Close()
+
+	acc0Key := os.Getenv("TEST_PRIVATE_KEY")
+	if acc0Key == "" {
+		t.Skip("skipping: set TEST_PRIVATE_KEY env var")
+	}
+
+	privateKey, err := crypto.HexToECDSA(acc0Key)
+	if err != nil {
+		t.Fatalf("invalid private key: %v", err)
+	}
+
+	_, err = sendRegisterTx(
+		rpcURL,
+		SHINZO_HUB_PRECOMPILED_VIEW_REGISTRY_ADDRESS,
+		privateKey,
+		[]byte("INVALID_VWL_DATA"),
+	)
+
+	if err == nil {
+		t.Fatal("expected sendRegisterTx to return error for invalid payload, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "reverted") {
+		t.Errorf("expected error to mention 'reverted', got: %s", err.Error())
+	}
+
+	t.Logf("correctly returned error: %v", err)
+}


### PR DESCRIPTION
## Description

`sendRegisterTx()` returned the tx hash immediately after `eth_sendRawTransaction` without checking the on-chain receipt. This meant reverted transactions were reported as successful deployments to the user, masking failures like closed ICA channels, invalid payloads, or out-of-gas errors.

  ## Changes

  - `sendRegisterTx()` now polls `eth_getTransactionReceipt` after submission (2s interval, 45s timeout)
  - Returns an error when `receipt.Status == 0` (reverted), including gas used and tx hash in the message
  - Return type changed from `string` to `txResult` struct carrying tx hash, gas used, and block number
  - Deploy output now shows gas used, block number, and wire size on success
  - Added integration test `TestSendRegisterTx_RevertsOnInvalidPayload` that sends invalid VWL data to the ViewRegistry precompile and verifies the revert is detected

## Related Issue
 #34 

  ## Steps to Test

  1. Start a local ShinzoHub testnet: `cd shinzohub && make sh-testnet`
  2. Export a test key: `export TEST_PRIVATE_KEY=$(./build/shinzohubd keys unsafe-export-eth-key acc0 --keyring-backend test --home ~/.shinzohub)`
  3. Run the integration test:
     ```bash
     cd shinzo-view-creator
     TEST_PRIVATE_KEY=$TEST_PRIVATE_KEY go test ./core/service/ -run TestSendRegisterTx_RevertsOnInvalidPayload -v -count=1
  4. Verify the test passes and logs an error containing "reverted"
  5. Optionally, deploy a real view to a local node and confirm the success output now includes gas used and block number

 ### Checklist
  - [x] Code compiles / runs                                                                                                           
  - [x] Tests added / updated                                                                                                          
  - [x] Documentation updated if needed
  - [x] PR is self-contained and focused                                                                                               
  - [x] Code does not break any existing features
  - [x] Code passes personal internal testing          

 ### Notes
  - The integration test requires a running local ShinzoHub node and skips gracefully when unavailable
  - This fix does not address the separate devnet issue (closed ICA channels to SourceHub), but it ensures the failure is now visible to the user instead of being silently reported as success
